### PR TITLE
Chart v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.2.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.2) (2019-11-26)
+- Fixes https://github.com/puppetlabs/pupperware/issues/187 and https://github.com/puppetlabs/pupperware/issues/188.
+- `r10k` now runs with the `puppet` username and group id - meaning all the files in `/etc/puppetlabs` are now owned by Puppet Server.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.1...v1.2.2)
+
 ## [v1.2.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.1) (2019-11-24)
 - Fixes for "r10k" extra container args.
 - Values file small fixes.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 1.2.1
+version: 1.2.2
 appVersion: 6.7.1
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/templates/puppetserver-deployment.yaml
+++ b/templates/puppetserver-deployment.yaml
@@ -32,17 +32,21 @@ spec:
             - mkdir -p /etc/puppetlabs/code/environments;
               mkdir -p /etc/puppetlabs/puppet/keys;
               mkdir -p /etc/puppetlabs/puppet/manifests;
+              chown -R puppet:puppet /etc/puppetlabs;
               {{- if .Values.hiera.config }}
               cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
+              chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
+              chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
               {{- if .Values.hiera.eyaml.private_key }}
               cp /etc/puppetlabs/puppet/configmap/private_key.pkcs7.pem /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem;
+              chown puppet:puppet /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem;
               {{- end }}
               {{- if .Values.hiera.eyaml.public_key }}
               cp /etc/puppetlabs/puppet/configmap/public_key.pkcs7.pem /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem;
+              chown puppet:puppet /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem;
               {{- end }}
-              chown -R puppet:puppet /etc/puppetlabs;
           securityContext:
             runAsUser: 0
             runAsNonRoot: false

--- a/templates/puppetserver-deployment.yaml
+++ b/templates/puppetserver-deployment.yaml
@@ -32,21 +32,17 @@ spec:
             - mkdir -p /etc/puppetlabs/code/environments;
               mkdir -p /etc/puppetlabs/puppet/keys;
               mkdir -p /etc/puppetlabs/puppet/manifests;
-              chown -R puppet:puppet /etc/puppetlabs;
               {{- if .Values.hiera.config }}
               cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
-              chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
-              chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
               {{- if .Values.hiera.eyaml.private_key }}
               cp /etc/puppetlabs/puppet/configmap/private_key.pkcs7.pem /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem;
-              chown puppet:puppet /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem;
               {{- end }}
               {{- if .Values.hiera.eyaml.public_key }}
               cp /etc/puppetlabs/puppet/configmap/public_key.pkcs7.pem /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem;
-              chown puppet:puppet /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem;
               {{- end }}
+              chown -R puppet:puppet /etc/puppetlabs;
           securityContext:
             runAsUser: 0
             runAsNonRoot: false

--- a/templates/r10k-cronjob.yaml
+++ b/templates/r10k-cronjob.yaml
@@ -37,6 +37,7 @@ spec:
                 - environment
                 - --config
                 - /etc/puppetlabs/puppet/r10k.yaml
+                - --puppetfile
               {{- range $key, $value := .Values.r10k.extraArgs }}
                 - {{ $value }}
               {{- end }}


### PR DESCRIPTION
- Fixes https://github.com/puppetlabs/pupperware/issues/187 and https://github.com/puppetlabs/pupperware/issues/188.
- `r10k` now runs with the `puppet` username and group id - meaning all the files in `/etc/puppetlabs` are now owned by Puppet Server.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.1...v1.2.2)
