### PR TITLE
separate cronjob for hiera; r10k cache; indentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,14 @@ Parameter | Description | Default
 `r10k.image` | r10k img | `puppet/r10k`
 `r10k.tag` | r10k img tag | `3.3.3`
 `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`
-`r10k.cronJob.schedule` | r10k cron job schedule policy | `*/2 * * * *`
-`r10k.resources` | r10k resource limits |``
-`r10k.extraArgs` | r10k additional container env args |``
-`r10k.extraEnv` | r10k additional container env vars |``
+`r10k.code.cronJob.schedule` | r10k code cron job schedule policy | `*/15 * * * *`
+`r10k.code.resources` | r10k code resource limits |``
+`r10k.code.extraArgs` | r10k code additional container env args |``
+`r10k.code.extraEnv` | r10k code additional container env vars |``
+`r10k.hiera.cronJob.schedule` | r10k hiera cron job schedule policy | `*/2 * * * *`
+`r10k.hiera.resources` | r10k hiera resource limits |``
+`r10k.hiera.extraArgs` | r10k hiera additional container env args |``
+`r10k.hiera.extraEnv` | r10k hiera additional container env vars |``
 `r10k.viaHttps.repo`| r10k https repo selector |``
 `r10k.viaHttps.credentials.username`| r10k https username |``
 `r10k.viaHttps.credentials.password`| r10k https password |``

--- a/README.md
+++ b/README.md
@@ -162,10 +162,14 @@ Parameter | Description | Default
 `r10k.image` | r10k img | `puppet/r10k`
 `r10k.tag` | r10k img tag | `3.3.3`
 `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`
-`r10k.cronJob.schedule` | r10k cron job schedule policy | `*/2 * * * *`
-`r10k.resources` | r10k resource limits |``
-`r10k.extraArgs` | r10k additional container env args |``
-`r10k.extraEnv` | r10k additional container env vars |``
+`r10k.code.cronJob.schedule` | r10k code cron job schedule policy | `*/15 * * * *`
+`r10k.code.resources` | r10k code resource limits |``
+`r10k.code.extraArgs` | r10k code additional container env args |``
+`r10k.code.extraEnv` | r10k code additional container env vars |``
+`r10k.hiera.cronJob.schedule` | r10k hiera cron job schedule policy | `*/2 * * * *`
+`r10k.hiera.resources` | r10k hiera resource limits |``
+`r10k.hiera.extraArgs` | r10k hiera additional container env args |``
+`r10k.hiera.extraEnv` | r10k hiera additional container env vars |``
 `r10k.viaHttps.repo`| r10k https repo selector |``
 `r10k.viaHttps.credentials.username`| r10k https username |``
 `r10k.viaHttps.credentials.password`| r10k https password |``

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -38,16 +38,6 @@ chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 heritage: {{ .Release.Service }}
 {{- end -}}
 
-{{- define "puppetserver.git_sync.labels" -}}
-{{ include "puppetserver.git_sync.matchLabels" . }}
-{{ include "puppetserver.common.metaLabels" . }}
-{{- end -}}
-
-{{- define "puppetserver.git_sync.matchLabels" -}}
-component: {{ .Values.git_sync.name | quote }}
-{{ include "puppetserver.common.matchLabels" . }}
-{{- end -}}
-
 {{- define "puppetserver.hiera.labels" -}}
 {{ include "puppetserver.hiera.matchLabels" . }}
 {{ include "puppetserver.common.metaLabels" . }}
@@ -156,19 +146,6 @@ Create the name for the PostgreSQL password secret key.
   {{- .Values.postgres.credentials.existingSecretKey -}}
 {{- else -}}
   password
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the name for the git-sync secret.
-*/}}
-{{- define "git_sync.secret" -}}
-{{- if .Values.git_sync.viaSsh.credentials.existingSecret -}}
-  {{- .Values.git_sync.viaSsh.credentials.existingSecret -}}
-{{- else if .Values.git_sync.viaHttps.credentials.existingSecret -}}
-  {{- .Values.git_sync.viaHttps.credentials.existingSecret -}}
-{{- else -}}
-  git-creds
 {{- end -}}
 {{- end -}}
 

--- a/templates/postgres-deployment.yaml
+++ b/templates/postgres-deployment.yaml
@@ -59,18 +59,18 @@ spec:
         - name: postgres-custom-extensions
           configMap:
             name: postgres-custom-extensions
-    {{- if .Values.nodeSelector.allPods }}
+      {{- if .Values.nodeSelector.allPods }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+      {{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | nindent 10 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+      {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations| nindent 10 }}
-    {{- end }}
-    {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+      {{ toYaml .Values.tolerations| nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
+      {{- end }}

--- a/templates/postgres-pvc.yaml
+++ b/templates/postgres-pvc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: postgres-claim
   labels:
     {{- include "puppetserver.postgres.labels" . | nindent 4 }}
-{{- if .Values.storage.annotations }}
+  {{- if .Values.storage.annotations }}
   annotations:
-{{ toYaml .Values.storage.annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml .Values.storage.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.storage.selector }}
   selector:
@@ -19,10 +19,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}
-{{- if .Values.storage.storageClass }}
-{{- if (eq "-" .Values.storage.storageClass) }}
+  {{- if .Values.storage.storageClass }}
+  {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.storage.storageClass }}"
-{{- end }}
-{{- end }}
+  {{- end }}
+  {{- end }}

--- a/templates/private_key.pkcs7.pem.yaml
+++ b/templates/private_key.pkcs7.pem.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
   private_key.pkcs7.pem: |-
-{{ .Values.hiera.eyaml.private_key | nindent 4 }}
+    {{ .Values.hiera.eyaml.private_key | nindent 4 }}
 {{- end }}

--- a/templates/public_key.pkcs7.pem.yaml
+++ b/templates/public_key.pkcs7.pem.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
   public_key.pkcs7.pem: |-
-{{ .Values.hiera.eyaml.public_key | nindent 4 }}
+    {{ .Values.hiera.eyaml.public_key | nindent 4 }}
 {{- end }}

--- a/templates/puppetboard-deployment.yaml
+++ b/templates/puppetboard-deployment.yaml
@@ -40,19 +40,19 @@ spec:
           ports:
             - name: puppetboard
               containerPort: 8000
-    {{- if .Values.nodeSelector.allPods }}
+      {{- if .Values.nodeSelector.allPods }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+        {{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | nindent 10 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations| nindent 10 }}
-    {{- end }}
-    {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+        {{ toYaml .Values.tolerations| nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
+      {{- end }}
 {{- end }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -59,18 +59,18 @@ spec:
         - name: puppetdb-storage
           persistentVolumeClaim:
             claimName: puppetdb-claim
-    {{- if .Values.nodeSelector.allPods }}
+      {{- if .Values.nodeSelector.allPods }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+        {{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | nindent 10 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations| nindent 10 }}
-    {{- end }}
-    {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+        {{ toYaml .Values.tolerations| nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
+      {{- end }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -55,18 +55,18 @@ spec:
         - name: puppetdb-storage
           persistentVolumeClaim:
             claimName: puppetdb-claim
-    {{- if .Values.nodeSelector.allPods }}
+      {{- if .Values.nodeSelector.allPods }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+        {{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | nindent 10 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations| nindent 10 }}
-    {{- end }}
-    {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+        {{ toYaml .Values.tolerations| nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
+      {{- end }}

--- a/templates/puppetdb-pvc.yaml
+++ b/templates/puppetdb-pvc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: puppetdb-claim
   labels:
     {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
-{{- if .Values.storage.annotations }}
+  {{- if .Values.storage.annotations }}
   annotations:
-{{ toYaml .Values.storage.annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml .Values.storage.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.storage.selector }}
   selector:
@@ -19,10 +19,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}
-{{- if .Values.storage.storageClass }}
-{{- if (eq "-" .Values.storage.storageClass) }}
+  {{- if .Values.storage.storageClass }}
+  {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.storage.storageClass }}"
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/templates/puppetserver-code-pvc.yaml
+++ b/templates/puppetserver-code-pvc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: puppet-code-claim
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-{{- if .Values.storage.annotations }}
+  {{- if .Values.storage.annotations }}
   annotations:
-{{ toYaml .Values.storage.annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml .Values.storage.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.storage.selector }}
   selector:
@@ -19,10 +19,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}
-{{- if .Values.storage.storageClass }}
-{{- if (eq "-" .Values.storage.storageClass) }}
+  {{- if .Values.storage.storageClass }}
+  {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.storage.storageClass }}"
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/templates/puppetserver-data-pvc.yaml
+++ b/templates/puppetserver-data-pvc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: puppet-serverdata-claim
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-{{- if .Values.storage.annotations }}
+  {{- if .Values.storage.annotations }}
   annotations:
-{{ toYaml .Values.storage.annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml .Values.storage.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.storage.selector }}
   selector:
@@ -19,10 +19,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}
-{{- if .Values.storage.storageClass }}
-{{- if (eq "-" .Values.storage.storageClass) }}
+  {{- if .Values.storage.storageClass }}
+  {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.storage.storageClass }}"
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/templates/puppetserver-deployment.yaml
+++ b/templates/puppetserver-deployment.yaml
@@ -104,6 +104,8 @@ spec:
               mountPath: /etc/puppetlabs/puppet/
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            - name: r10k-cache-storage
+              mountPath: /var/tmp/r10k_cache/
       volumes:
         - name: puppet-code-storage
           persistentVolumeClaim:
@@ -114,6 +116,9 @@ spec:
         - name: puppet-serverdata-storage
           persistentVolumeClaim:
             claimName: puppet-serverdata-claim
+        - name: r10k-cache-storage
+          persistentVolumeClaim:
+            claimName: r10k-cache-claim
         {{- if .Values.hiera.config }}
         - name: hiera-volume
           configMap:

--- a/templates/puppetserver-deployment.yaml
+++ b/templates/puppetserver-deployment.yaml
@@ -16,9 +16,9 @@ spec:
         {{- include "puppetserver.puppetserver.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/hiera-configmap.yaml") . | sha256sum }}
-      {{- if .Values.podAnnotations }}
+        {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       hostname: {{ template "puppetserver.puppetserver.serviceName" . }}
       initContainers:
@@ -132,23 +132,23 @@ spec:
           configMap:
             name: eyamlpriv-config
         {{- end }}
-    {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
+      {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
       nodeSelector:
-    {{- if (.Values.nodeSelector.allPods) }}
-{{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
-    {{- end }}
-    {{- if (.Values.nodeSelector.commonStoragePods) }}
-{{ toYaml .Values.nodeSelector.commonStoragePods | nindent 10 }}
-    {{- end }}
-    {{- end }}
-    {{- if .Values.affinity }}
+      {{- if (.Values.nodeSelector.allPods) }}
+        {{ toYaml .Values.nodeSelector.allPods | nindent 10 }}
+      {{- end }}
+      {{- if (.Values.nodeSelector.commonStoragePods) }}
+        {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 10 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | nindent 10 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations| nindent 10 }}
-    {{- end }}
-    {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+        {{ toYaml .Values.tolerations| nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
+      {{- end }}

--- a/templates/puppetserver-ingress.yaml
+++ b/templates/puppetserver-ingress.yaml
@@ -5,19 +5,19 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-{{- if .Values.puppetserver.ingress.annotations }}
+  {{- if .Values.puppetserver.ingress.annotations }}
   annotations:
-{{ toYaml .Values.puppetserver.ingress.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml .Values.puppetserver.ingress.annotations | indent 4 }}
+  {{- end }}
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-{{- range $key, $value := .Values.puppetserver.ingress.extraLabels }}
+    {{- range $key, $value := .Values.puppetserver.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
-{{- end }}
+    {{- end }}
   name: {{ template "puppetserver.fullname" . }}
 spec:
   rules:
-  {{- range .Values.puppetserver.ingress.hosts }}
+    {{- range .Values.puppetserver.ingress.hosts }}
     {{- $url := splitList "/" . }}
     - host: {{ first $url }}
       http:
@@ -26,9 +26,9 @@ spec:
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-  {{- end -}}
-{{- if .Values.puppetserver.ingress.tls }}
+    {{- end -}}
+  {{- if .Values.puppetserver.ingress.tls }}
   tls:
-{{ toYaml .Values.puppetserver.ingress.tls | indent 4 }}
+    {{ toYaml .Values.puppetserver.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/templates/puppetserver-pvc.yaml
+++ b/templates/puppetserver-pvc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: puppet-puppet-claim
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-{{- if .Values.storage.annotations }}
+  {{- if .Values.storage.annotations }}
   annotations:
-{{ toYaml .Values.storage.annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml .Values.storage.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.storage.selector }}
   selector:
@@ -19,10 +19,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}
-{{- if .Values.storage.storageClass }}
-{{- if (eq "-" .Values.storage.storageClass) }}
+  {{- if .Values.storage.storageClass }}
+  {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.storage.storageClass }}"
-{{- end }}
-{{- end }}
+  {{- end }}
+  {{- end }}

--- a/templates/puppetserver-pvc.yaml
+++ b/templates/puppetserver-pvc.yaml
@@ -26,10 +26,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}
-{{- if .Values.storage.storageClass }}
-{{- if (eq "-" .Values.storage.storageClass) }}
+  {{- if .Values.storage.storageClass }}
+  {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.storage.storageClass }}"
-{{- end }}
-{{- end }}
+  {{- end }}
+  {{- end }}

--- a/templates/puppetserver-service.yaml
+++ b/templates/puppetserver-service.yaml
@@ -4,12 +4,12 @@ metadata:
   name: {{ template "puppetserver.puppetserver.serviceName" . }}
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-  {{- if .Values.puppetserver.service.labels }}
+    {{- if .Values.puppetserver.service.labels }}
     {{ toYaml .Values.puppetserver.service.labels | indent 4 }}
-  {{- end }}
+    {{- end }}
   {{- if .Values.puppetserver.service.annotations }}
   annotations:
-{{ toYaml .Values.puppetserver.service.annotations | indent 4 }}
+    {{ toYaml .Values.puppetserver.service.annotations | indent 4 }}
   {{- end }}
 spec:
   ports:

--- a/templates/r10k-cache-pvc.yaml
+++ b/templates/r10k-cache-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: r10k-cache-claim
+  labels:
+    {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/templates/r10k-code-configmap.yaml
+++ b/templates/r10k-code-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: r10k-config
+  name: r10k-code-config
   labels:
     {{- include "puppetserver.r10k.labels" . | nindent 4 }}
 data:

--- a/templates/r10k-code-cronjob.yaml
+++ b/templates/r10k-code-cronjob.yaml
@@ -2,14 +2,14 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: r10k-deploy
+  name: r10k-code-deploy
   labels:
     {{- include "puppetserver.r10k.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
       {{- include "puppetserver.r10k.matchLabels" . | nindent 6 }}
-  schedule: "{{.Values.r10k.cronJob.schedule}}"
+  schedule: "{{.Values.r10k.code.cronJob.schedule}}"
   jobTemplate:
     spec:
       template:
@@ -22,13 +22,13 @@ spec:
           {{- end }}
         spec:
           containers:
-            - name: r10k
+            - name: r10k-code
               image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
               imagePullPolicy: "{{.Values.r10k.pullPolicy}}"
               resources:
-                {{- toYaml .Values.r10k.resources | nindent 16 }}
+                {{- toYaml .Values.r10k.code.resources | nindent 16 }}
               env:
-                {{- range $key, $value := .Values.r10k.extraEnv }}
+                {{- range $key, $value := .Values.r10k.code.extraEnv }}
                 - name: {{ $key }}
                   value: {{ $value }}
                 {{- end }}
@@ -38,7 +38,7 @@ spec:
                 - --config
                 - /etc/puppetlabs/puppet/r10k.yaml
                 - --puppetfile
-                {{- range $key, $value := .Values.r10k.extraArgs }}
+                {{- range $key, $value := .Values.r10k.code.extraArgs }}
                 - {{ $value }}
                 {{- end }}
               volumeMounts:
@@ -60,7 +60,7 @@ spec:
                 claimName: puppet-code-claim
             - name: r10k-volume
               configMap:
-                name: r10k-config
+                name: r10k-code-config
             - name: r10k-cache-storage
               persistentVolumeClaim:
                 claimName: r10k-cache-claim

--- a/templates/r10k-cronjob.yaml
+++ b/templates/r10k-cronjob.yaml
@@ -51,6 +51,8 @@ spec:
                   subPath: r10k.yaml
                 - name: puppet-code-storage
                   mountPath: /etc/puppetlabs/code/
+                - name: r10k-cache-storage
+                  mountPath: /var/tmp/r10k_cache/
           restartPolicy: OnFailure
           volumes:
             - name: puppet-code-storage
@@ -59,6 +61,9 @@ spec:
             - name: r10k-volume
               configMap:
                 name: r10k-config
+            - name: r10k-cache-storage
+              persistentVolumeClaim:
+                claimName: r10k-cache-claim
             {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
             - name: r10k-secret
               secret:

--- a/templates/r10k-cronjob.yaml
+++ b/templates/r10k-cronjob.yaml
@@ -38,9 +38,9 @@ spec:
                 - --config
                 - /etc/puppetlabs/puppet/r10k.yaml
                 - --puppetfile
-              {{- range $key, $value := .Values.r10k.extraArgs }}
+                {{- range $key, $value := .Values.r10k.extraArgs }}
                 - {{ $value }}
-              {{- end }}
+                {{- end }}
               volumeMounts:
                 {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
                 - name: r10k-secret
@@ -65,24 +65,24 @@ spec:
                 secretName: {{ template "r10k.secret" . }}
                 defaultMode: 288 # = mode 0440
             {{- end }}
-        {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
+          {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:
-        {{- if (.Values.nodeSelector.allPods) }}
-{{ toYaml .Values.nodeSelector.allPods | nindent 14 }}
-        {{- end }}
-        {{- if (.Values.nodeSelector.commonStoragePods) }}
-{{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
-        {{- end }}
-        {{- end }}
-        {{- if .Values.affinity }}
+          {{- if (.Values.nodeSelector.allPods) }}
+            {{ toYaml .Values.nodeSelector.allPods | nindent 14 }}
+          {{- end }}
+          {{- if (.Values.nodeSelector.commonStoragePods) }}
+            {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.affinity }}
           affinity:
-{{ toYaml .Values.affinity | nindent 14 }}
-        {{- end }}
-        {{- if .Values.tolerations }}
+            {{ toYaml .Values.affinity | nindent 14 }}
+          {{- end }}
+          {{- if .Values.tolerations }}
           tolerations:
-{{ toYaml .Values.tolerations| nindent 14 }}
-        {{- end }}
-        {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+            {{ toYaml .Values.tolerations| nindent 14 }}
+          {{- end }}
+          {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
           priorityClassName: {{ .Values.priorityClassName }}
-        {{- end }}
+          {{- end }}
 {{- end }}

--- a/templates/r10k-hiera-configmap.yaml
+++ b/templates/r10k-hiera-configmap.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.hiera.hieradataurl }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: r10k-hiera-config
+  labels:
+    {{- include "puppetserver.r10k.labels" . | nindent 4 }}
+data:
+  r10k.yaml: |
+    # The location to use for storing cached Git repos
+    :cachedir: '/var/tmp/r10k_cache'
+
+    # A list of git repositories to create
+    :sources:
+      # This will clone the git repository and instantiate an environment per
+      # branch in '/etc/puppetlabs/code/hiera-data'
+      :hiera_repo:
+        remote: '{{.Values.hiera.hieradataurl}}'
+        basedir: '/etc/puppetlabs/code/hiera-data'
+
+    :git:
+      provider: 'rugged' # Either 'shellgit' or 'rugged', defaults to 'shellgit'
+      {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+      {{- if and (not .Values.r10k.viaSsh.repo) (not .Values.r10k.viaHttps.repo) }}
+      private_key: '/root/.ssh/id_rsa'
+      {{- end }}
+      {{- if (eq (.Values.r10k.viaSsh.repo | toString) "hiera_repo") (ne (.Values.r10k.viaHttps.repo | toString) "hiera_repo") }}
+      repositories:
+        - remote: '{{.Values.hiera.hieradataurl}}'
+          private_key: '/root/.ssh/id_rsa'
+      {{- end }}
+      {{- end }}
+      {{- if and (.Values.r10k.viaHttps.credentials.username) (.Values.r10k.viaHttps.credentials.password) }}
+      {{- if and (not .Values.r10k.viaHttps.repo) (not .Values.r10k.viaSsh.repo) }}
+      username: '{{.Values.r10k.viaHttps.credentials.username}}'
+      password: '{{.Values.r10k.viaHttps.credentials.password}}'
+      {{- end }}
+      {{- if and (eq (.Values.r10k.viaHttps.repo | toString) "hiera_repo") (ne (.Values.r10k.viaSsh.repo | toString) "hiera_repo") }}
+      {{- if not .Values.r10k.viaSsh.repo }}
+      repositories:
+      {{- end }}
+        - remote: '{{.Values.hiera.hieradataurl}}'
+          username: '{{.Values.r10k.viaHttps.credentials.username}}'
+          password: '{{.Values.r10k.viaHttps.credentials.password}}'
+      {{- end }}
+      {{- end }}
+{{- end }}

--- a/templates/r10k-hiera-cronjob.yaml
+++ b/templates/r10k-hiera-cronjob.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.puppetserver.puppeturl }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: r10k-hiera-deploy
+  labels:
+    {{- include "puppetserver.r10k.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "puppetserver.r10k.matchLabels" . | nindent 6 }}
+  schedule: "{{.Values.r10k.hiera.cronJob.schedule}}"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "puppetserver.r10k.labels" . | nindent 12 }}
+          {{- if .Values.podAnnotations }}
+          annotations:
+            {{- toYaml .Values.podAnnotations | nindent 12 }}
+          {{- end }}
+        spec:
+          containers:
+            - name: r10k
+              image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
+              imagePullPolicy: "{{.Values.r10k.pullPolicy}}"
+              resources:
+                {{- toYaml .Values.r10k.hiera.resources | nindent 16 }}
+              env:
+                {{- range $key, $value := .Values.r10k.hiera.extraEnv }}
+                - name: {{ $key }}
+                  value: {{ $value }}
+                {{- end }}
+              args:
+                - deploy
+                - environment
+                - --config
+                - /etc/puppetlabs/puppet/r10k.yaml
+                - --puppetfile
+                {{- range $key, $value := .Values.r10k.hiera.extraArgs }}
+                - {{ $value }}
+                {{- end }}
+              volumeMounts:
+                {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+                - name: r10k-secret
+                  mountPath: /root/.ssh
+                {{- end }}
+                - name: r10k-volume
+                  mountPath: /etc/puppetlabs/puppet/r10k.yaml
+                  subPath: r10k.yaml
+                - name: puppet-code-storage
+                  mountPath: /etc/puppetlabs/code/
+                - name: r10k-cache-storage
+                  mountPath: /var/tmp/r10k_cache/
+          restartPolicy: OnFailure
+          volumes:
+            - name: puppet-code-storage
+              persistentVolumeClaim:
+                claimName: puppet-code-claim
+            - name: r10k-volume
+              configMap:
+                name: r10k-hiera-config
+            - name: r10k-cache-storage
+              persistentVolumeClaim:
+                claimName: r10k-cache-claim
+            {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+            - name: r10k-secret
+              secret:
+                secretName: {{ template "r10k.secret" . }}
+                defaultMode: 288 # = mode 0440
+            {{- end }}
+          {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
+          nodeSelector:
+          {{- if (.Values.nodeSelector.allPods) }}
+            {{ toYaml .Values.nodeSelector.allPods | nindent 14 }}
+          {{- end }}
+          {{- if (.Values.nodeSelector.commonStoragePods) }}
+            {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.affinity }}
+          affinity:
+            {{ toYaml .Values.affinity | nindent 14 }}
+          {{- end }}
+          {{- if .Values.tolerations }}
+          tolerations:
+            {{ toYaml .Values.tolerations| nindent 14 }}
+          {{- end }}
+          {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+          priorityClassName: {{ .Values.priorityClassName }}
+          {{- end }}
+{{- end }}

--- a/templates/r10k-hiera-cronjob.yaml
+++ b/templates/r10k-hiera-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetserver.puppeturl }}
+{{- if .Values.hiera.hieradataurl }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -81,51 +81,40 @@ r10k:
   image: puppet/r10k
   tag: 3.3.3
   pullPolicy: IfNotPresent
-  resources: {}
-  #  requests:
-  #    memory: 256Mi
-  #    cpu: 250m
-  #  limits:
-  #    memory: 512Mi
-  #    cpu: 500m
-  cronJob:
-    schedule: "*/5 * * * *"
-  ## Additional r10k container arguments
-  extraArgs: {}
-  #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
-  #  - --trace
-  #  - --color
-  ## Additional r10k container environment variables
-  extraEnv: {}
-  ## Cloning via HTTPS protocol with authentication
-  ##
-  viaHttps:
-    ## Leave empty - if HTTPS should be used for both - Puppet and Hiera repos.
-    repo: ""   # "puppet_repo" or "hiera_repo"
-    credentials:
-      username: ""
-      ## The password might be your user-generated token
-      ## in case MFA is enabled.
-      password: ""
-      ## Or set the "username" and "password" from a pre-existing K8s secret
-      existingSecret: ""
-  ## Cloning via SSH protocol with authentication
-  ##
-  viaSsh:
-    ## Leave empty - if SSH should be used for both - Puppet and Hiera repos.
-    repo: ""   # "puppet_repo" or "hiera_repo"
-    credentials:
-      ssh:
-        ## A multi-line string
-        value:  # |
-          #  PRIV_KEY CONTENTS
-      known_hosts:
-        ## A multi-line string
-        value:  # |
-          #  KNOWN_HOSTS CONTENTS
-      ## Or set the git-sync Known Hosts file and SSH Private Key
-      ## from a pre-existing K8s secret
-      existingSecret: ""
+  code:
+    resources: {}
+    #  requests:
+    #    memory: 256Mi
+    #    cpu: 250m
+    #  limits:
+    #    memory: 512Mi
+    #    cpu: 500m
+    cronJob:
+      schedule: "*/15 * * * *"
+    ## Additional r10k container arguments
+    extraArgs: {}
+    #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
+    #  - --trace
+    #  - --color
+    ## Additional puppetserver container environment variables
+    extraEnv: {}
+  hiera:
+    resources: {}
+    #  requests:
+    #    memory: 256Mi
+    #    cpu: 250m
+    #  limits:
+    #    memory: 512Mi
+    #    cpu: 500m
+    cronJob:
+      schedule: "*/2 * * * *"
+    ## Additional r10k container arguments
+    extraArgs: {}
+    #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
+    #  - --trace
+    #  - --color
+    ## Additional puppetserver container environment variables
+    extraEnv: {}
 
 ## PostgreSQL Configuration for PuppetDB
 ##

--- a/values.yaml
+++ b/values.yaml
@@ -76,22 +76,41 @@ r10k:
   image: puppet/r10k
   tag: 3.3.3
   pullPolicy: IfNotPresent
-  resources: {}
-  #  requests:
-  #    memory: 256Mi
-  #    cpu: 250m
-  #  limits:
-  #    memory: 512Mi
-  #    cpu: 500m
-  cronJob:
-    schedule: "*/5 * * * *"
-  ## Additional r10k container arguments
-  extraArgs: {}
-  #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
-  #  - --trace
-  #  - --color
-  ## Additional puppetserver container environment variables
-  extraEnv: {}
+  code:
+    resources: {}
+    #  requests:
+    #    memory: 256Mi
+    #    cpu: 250m
+    #  limits:
+    #    memory: 512Mi
+    #    cpu: 500m
+    cronJob:
+      schedule: "*/15 * * * *"
+    ## Additional r10k container arguments
+    extraArgs: {}
+    #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
+    #  - --trace
+    #  - --color
+    ## Additional puppetserver container environment variables
+    extraEnv: {}
+  hiera:
+    resources: {}
+    #  requests:
+    #    memory: 256Mi
+    #    cpu: 250m
+    #  limits:
+    #    memory: 512Mi
+    #    cpu: 500m
+    cronJob:
+      schedule: "*/2 * * * *"
+    ## Additional r10k container arguments
+    extraArgs: {}
+    #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
+    #  - --trace
+    #  - --color
+    ## Additional puppetserver container environment variables
+    extraEnv: {}
+
   ## Cloning via HTTPS protocol with authentication
   ##
   viaHttps:


### PR DESCRIPTION
- Using separate cronjobs for code (control+modules) and hiera allows more frequent updates for the things that change more frequently (hopefully hiera).
- Using r10k cache should speed up code deploys that make heavy use of forge modules.  Unfortunately, r10k seems to ignore cache for git based repos.
- Indentation and git_sync cleanup was just because I was there and wanted to make that more consistent.