### PR TITLE
This is what I had to adjust to get it up and running on an Azure AKS cluster

### DIFF
--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -20,7 +20,7 @@ data:
       provider: 'rugged' # Either 'shellgit' or 'rugged', defaults to 'shellgit'
     {{- with .Values.r10k.code.viaSsh.credentials }}
     {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-      private_key: '/root/.ssh/id_rsa'
+      private_key: '/home/puppet/.ssh/id_rsa'
     {{- end }}
     {{- end }}
       repositories:

--- a/templates/r10k-code.cronjob.yaml
+++ b/templates/r10k-code.cronjob.yaml
@@ -53,7 +53,7 @@ spec:
               {{- with .Values.r10k.code.viaSsh.credentials }}
               {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
                 - name: r10k-code-secret
-                  mountPath: /root/.ssh
+                  mountPath: /home/puppet/.ssh
               {{- end }}
               {{- end }}
                 - name: r10k-volume
@@ -80,7 +80,7 @@ spec:
             - name: r10k-code-secret
               secret:
                 secretName: {{ template "r10k.code.secret" . }}
-                defaultMode: 288 # = mode 0440
+                defaultMode: 292 # = mode 0444
           {{- end }}
         {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:
@@ -91,7 +91,10 @@ spec:
             {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.affinity }}
+        {{- if .Values.r10k.affinity }}
+          affinity:
+            {{ toYaml .Values.r10k.affinity | nindent 14 }}
+        {{- else if .Values.affinity }}
           affinity:
             {{ toYaml .Values.affinity | nindent 14 }}
         {{- end }}

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -22,7 +22,7 @@ data:
       provider: 'rugged' # Either 'shellgit' or 'rugged', defaults to 'shellgit'
     {{- with .Values.r10k.hiera.viaSsh.credentials }}
     {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-      private_key: '/root/.ssh/id_rsa'
+      private_key: '/home/puppet/.ssh/id_rsa'
     {{- end }}
     {{- end }}
       repositories:

--- a/templates/r10k-hiera.cronjob.yaml
+++ b/templates/r10k-hiera.cronjob.yaml
@@ -53,7 +53,7 @@ spec:
               {{- with .Values.r10k.hiera.viaSsh.credentials }}
               {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
                 - name: r10k-hiera-secret
-                  mountPath: /root/.ssh
+                  mountPath: /home/puppet/.ssh
               {{- end }}
               {{- end }}
                 - name: r10k-volume
@@ -80,7 +80,7 @@ spec:
             - name: r10k-hiera-secret
               secret:
                 secretName: {{ template "r10k.hiera.secret" . }}
-                defaultMode: 288 # = mode 0440
+                defaultMode: 292 # = mode 0444
           {{- end }}
         {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:
@@ -91,7 +91,10 @@ spec:
             {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.affinity }}
+        {{- if .Values.r10k.affinity }}
+          affinity:
+            {{ toYaml .Values.r10k.affinity | nindent 14 }}
+        {{- else if .Values.affinity }}
           affinity:
             {{ toYaml .Values.affinity | nindent 14 }}
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -81,6 +81,8 @@ r10k:
   image: puppet/r10k
   tag: 3.3.3
   pullPolicy: IfNotPresent
+  affinity: {}
+
   code:
     resources: {}
     #  requests:


### PR DESCRIPTION
* Fix location of ssh key as the user is puppet and not root and allow
puppet user to access it
* Allow to specify different affinity for r10k cronjobs (e.g. to have
them running on the same node as the puppetserver pod to avoid issues
with different nodes accessing the persistent volume where the code is
stored on)