### PR TITLE
Add Comments for "r10k" optional affinity for pod assignment. Security Fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.6.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.6.0) (2019-12-26)
+
+- Add optional affinity for "r10k" pod assignment.
+- File permission fixes for "r10k" jobs' SSH keys.
+- Security fixes for the "r10k" jobs.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.5.3...v1.6.0)
+
 ## [v1.5.3](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.5.3) (2019-12-09)
 
 - Small README fixes.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Parameter | Description | Default
 `r10k.image` | r10k img | `puppet/r10k`
 `r10k.tag` | r10k img tag | `3.3.3`
 `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`
+`r10k.affinity` | r10k pod assignment affinity |``
 `r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`
 `r10k.code.cronJob.concurrencyPolicy` | r10k control repo cron job concurrency policy | `Forbid`
 `r10k.code.cronJob.restartPolicy` | r10k control repo cron job restart policy | `Never`

--- a/templates/r10k-code.cronjob.yaml
+++ b/templates/r10k-code.cronjob.yaml
@@ -61,6 +61,9 @@ spec:
                   subPath: r10k.yaml
                 - name: puppet-code-storage
                   mountPath: /etc/puppetlabs/code/
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            fsGroup: 999   # "puppet" GID
         {{- with .Values.r10k.code.cronJob }}
         {{- if .restartPolicy }}
           restartPolicy: {{ .restartPolicy }}
@@ -80,7 +83,8 @@ spec:
             - name: r10k-code-secret
               secret:
                 secretName: {{ template "r10k.code.secret" . }}
-                defaultMode: 292 # = mode 0444
+                defaultMode: 288 # = mode 0440
+                fsGroup: 999   # "puppet" GID
           {{- end }}
         {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:

--- a/templates/r10k-hiera.cronjob.yaml
+++ b/templates/r10k-hiera.cronjob.yaml
@@ -61,6 +61,9 @@ spec:
                   subPath: r10k.yaml
                 - name: puppet-code-storage
                   mountPath: /etc/puppetlabs/code/
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            fsGroup: 999   # "puppet" GID
         {{- with .Values.r10k.hiera.cronJob }}
         {{- if .restartPolicy }}
           restartPolicy: {{ .restartPolicy }}
@@ -80,7 +83,8 @@ spec:
             - name: r10k-hiera-secret
               secret:
                 secretName: {{ template "r10k.hiera.secret" . }}
-                defaultMode: 292 # = mode 0444
+                defaultMode: 288 # = mode 0440
+                fsGroup: 999   # "puppet" GID
           {{- end }}
         {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -81,8 +81,25 @@ r10k:
   image: puppet/r10k
   tag: 3.3.3
   pullPolicy: IfNotPresent
+  ## Affinity for "r10k" pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note that the "puppetserver" and "r10k" components of the Puppet Server
+  ## use common storage. That common storage requirement might impose
+  ## certain pod assignment scenarios. It might be required the "puppetserver" and "r10k"
+  ## components to sit in the same K8s Node.
+  ## For that matter optional pod affinity is made available for the "r10k" pod if need be.
+  ## The exemplary configuration can be used without modification,
+  ## if "Values.puppetserver.name" is kept unchanged.
   affinity: {}
-
+  #  podAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #    - labelSelector:
+  #        matchExpressions:
+  #        - key: component
+  #          operator: In
+  #          values:
+  #          - puppetserver
+  #      topologyKey: "kubernetes.io/hostname"
   code:
     resources: {}
     #  requests:


### PR DESCRIPTION
- Add comments for "r10k" optional pod assignment affinity in `values.yaml`.
- File permission fixes for "r10k" jobs' SSH keys.
- Security fixes for the "r10k" jobs.
- Update README and CHANGELOG.
