### PR TITLE
Update puppetserver-ingress-masters.yaml

### DIFF
--- a/templates/puppetserver-ingress-masters.yaml
+++ b/templates/puppetserver-ingress-masters.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- range $key, $value := .Values.puppetserver.masters.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
     {{- end }}
-  name: {{ template "puppetserver.fullname" . }}-compilers
+  name: {{ template "puppetserver.fullname" . }}-masters
 spec:
   rules:
     {{- range .Values.puppetserver.masters.ingress.hosts }}


### PR DESCRIPTION
changing the naming of the ingress from *-compilers to *-masters or the chart will fail if using ingresses on both