### PR TITLE
(maint) Add a github action for on-demand chart releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+name: Lint and publish puppetserver helm chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      helmRepoURL:
+        description: "URL for helm repo"
+        required: true
+        default: https://puppetlabs.github.io/puppetserver-helm-chart
+      githubRepo:
+        description: "username/repo for the github repo hosting the gh-pages branch"
+        required: true
+        default: puppetlabs/puppetserver-helm-chart
+
+jobs:
+  lint-and-publish:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HELM_REPO_URL: ${{ github.event.inputs.helmRepoURL }}
+      GITHUB_REPO: ${{ github.event.inputs.githubRepo }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+      - uses: azure/setup-helm@v1
+      - name: lint
+        run: |
+          helm lint .
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Set the version
+        run: |
+          echo "::set-env name=version::$(grep 'version:' Chart.yaml| awk '{print $2}')"
+      - name: Package the chart
+        run: |
+          helm package . --destination .release-packages --dependency-update
+      - name: Prep release notes
+        run: |
+          release_notes=`sed -n '/^## \['v${{ env.version }}'\]/,/^## /p' CHANGELOG.md | sed -n '/^- /p'`
+          echo "RELEASE NOTES: $release_notes"
+          echo "$release_notes" > body.md
+          release_name=`echo "$release_notes"| head -1 | sed 's/^- //'`
+          echo "::set-env name=release_name::$release_name"
+      - name: Make the release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ env.version }}
+          release_name: ${{ env.release_name }}
+          body_path: body.md
+      - name: upload artifacts to the release
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./.release-packages/puppetserver-${{ env.version }}.tgz
+          asset_name: puppetserver-${{ env.version }}.tgz
+          asset_content_type: application/gzip
+      - name: update ghpages
+        run: |
+          gh_pages_worktree=$(mktemp -d)
+          git worktree add "$gh_pages_worktree" gh-pages
+          cp .release-packages/puppetserver-${{ env.version }}.tgz $gh_pages_worktree
+          cp CHANGELOG.md README.md LICENSE OWNERS $gh_pages_worktree
+          helm repo index $gh_pages_worktree --url $HELM_REPO_URL
+          pushd "$gh_pages_worktree" > /dev/null
+          git add index.yaml puppetserver-${{ env.version }}.tgz
+          git commit --message "puppetserver-${{ env.version }} release"
+          git commit --all --message "Sync files from master branch" ||:
+          repo_url="https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPO"
+          git push "$repo_url" gh-pages
+          popd > /dev/null


### PR DESCRIPTION
When run, this action will lint the chart, parse the version from
Chart.yaml, parse release notes from CHANGELOG.md, build the chart,
publish the release and upload artifacts, and update the gh-pages branch
for the release, including copying over any changes in CHANGELOG.md,
LICENSE, OWNERS, and README.md files.