### PR TITLE
[v4.4.0] Allow for changing the default Puppet Server ports for Masters and Compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v4.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.0) (2020-07-24)
+
+- Liveness and readiness probes for Puppet Server.
+- Small fixes.
+
+[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.2.0...v4.3.0)
+
 ## [v4.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.2.0) (2020-06-23)
 
 - Add Helm v2 backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 ## [v4.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.0) (2020-07-24)
 
 - Liveness and readiness probes for Puppet Server.
-- Small fixes.
+- Adjust further resource naming.
+- Style improvements in `README`.
+- Small fixes in `values`.
 
 [Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.2.0...v4.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v4.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.1) (2020-07-26)
+
+- Put warning for changing the default puppetserver port in `values.yaml`.
+- Code style fixes in "values.yaml".
+- Improve Testing section in `README.md`.
+
+[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.3.0...v4.3.1)
+
 ## [v4.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.0) (2020-07-24)
 
 - Liveness and readiness probes for Puppet Server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v4.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.1) (2020-07-26)
+## [v4.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.4.0) (2020-08-31)
 
-- Put warning for changing the default puppetserver port in `values.yaml`.
+- Allow for changing the default Puppet Server port for Masters and Compilers.
+- Bump `puppetserver` to `v6.12.1`, `puppetdb` to `v6.11.3`, `r10k` to `v3.5.2`, `puppetboard` to `v2.2.0`, `postgres` to `v9.6.19`.
 - Code style fixes in "values.yaml".
 - Improve Testing section in `README.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v4.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.4.0) (2020-08-31)
+## [v4.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.4.0) (2020-08-24)
 
 - Allow for changing the default Puppet Server port for Masters and Compilers.
 - Switch to percentage `rollingUpdate` strategy for Puppet Masters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Allow for changing the default Puppet Server port for Masters and Compilers.
 - Bump `puppetserver` to `v6.12.1`, `puppetdb` to `v6.11.3`, `r10k` to `v3.5.2`, `puppetboard` to `v2.2.0`, `postgres` to `v9.6.19`.
 - Code style fixes in "values.yaml".
-- Improve Testing section in `README.md`.
+- Improve `Testing the Deployed Chart Resources` in `README.md`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.3.0...v4.3.1)
+[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.3.0...v4.4.0)
 
 ## [v4.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.0) (2020-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 ## [v4.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.4.0) (2020-08-31)
 
 - Allow for changing the default Puppet Server port for Masters and Compilers.
+- Switch to percentage `rollingUpdate` strategy for Puppet Masters.
+- Set `updateStrategy` to `RollingUpdate` for Puppet Compilers.
 - Bump `puppetserver` to `v6.12.1`, `puppetdb` to `v6.11.3`, `r10k` to `v3.5.2`, `puppetboard` to `v2.2.0`, `postgres` to `v9.6.19`.
 - Code style fixes in "values.yaml".
 - Improve `Testing the Deployed Chart Resources` in `README.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 
 ## [v4.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.4.0) (2020-08-24)
 
-- Allow for changing the default Puppet Server port for Masters and Compilers.
+- Allow for changing the default Puppet Server ports for Masters and Compilers.
 - Switch to percentage `rollingUpdate` strategy for Puppet Masters.
 - Set `updateStrategy` to `RollingUpdate` for Puppet Compilers.
 - Bump `puppetserver` to `v6.12.1`, `puppetdb` to `v6.11.3`, `r10k` to `v3.5.2`, `puppetboard` to `v2.2.0`, `postgres` to `v9.6.19`.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: puppetserver
 type: application
-version: 4.2.0
+version: 4.3.0
 appVersion: 6.10.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 4.3.0
+version: 4.3.1
 appVersion: 6.10.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: puppetserver
-version: 4.3.1
-appVersion: 6.10.0
+version: 4.4.0
+appVersion: 6.12.1
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ kill %[job_numbers_above]
 
 ## Credits
 
-* [Miroslav Hadzhiev](mailto:miroslav.hadzhiev@gmail.com), Lead Author and Developer
+* [Miroslav Hadzhiev](https://www.linkedin.com/in/mehadzhiev/), Lead Author and Developer
 * [Pupperware Team](mailto:pupperware@puppet.com), Owner
 * [Sean Conley](mailto:slconley@gmail.com), Developer
 * [Morgan Rhodes](mailto:morgan@puppet.com), Developer

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ In case a Load Balancer (LB) must sit in front of Puppet Server - please keep in
 
 The Ingress resource is disabled by default, but if it is enabled then ssl-passthrough must be used so that puppet agents will get the expected server certificate when connecting to the service.  This feature must be enabled on the Ingress resource itself, but also must be enabled via command line argument to the NGINX Ingress Controller.  More information on that can be found [here](<https://kubernetes.github.io/ingress-nginx/user-guide/cli-arguments/>).
 
+> **NOTE**: Ingress URLs must be passed in the `Values.puppetserver.masters.fqdns.alternateServerNames`. Also - in the `Values.puppetserver.compilers.fqdns.alternateServerNames` (if Puppet Compilers and their Ingress resources are deployed).
+
 ## Migrating from Bare-Metal Puppet Infrastructure
 
 ### Auto-Signing Certificate Requests
@@ -256,6 +258,8 @@ docker run -dit --network host --name goofy_xtigyro --entrypoint /bin/bash puppe
 docker exec -it goofy_xtigyro bash
 puppet agent -t --server puppet --masterport 8140 --test --waitforcert 15 --certname ubuntu-goofy_xtigyro
 puppet agent -t --server puppet-compilers --ca_server agents-to-puppet --masterport 8141 --ca_port 8140 --test --certname ubuntu-goofy_xtigyro
+# if Ingress is used, e.g.
+# puppet agent -t --server puppet.local.compilers --ca_server puppet.local.masters --masterport 443 --ca_port 443 --test --certname ubuntu-goofy_xtigyro
 puppet agent -t --server puppet-compilers --masterport 8141 --test --certname ubuntu-goofy_xtigyro
 exit
 docker rm -f goofy_xtigyro

--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.masters.extraEnv` | puppetserver masters additional container env vars |``|
 | `puppetserver.masters.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
 | `puppetserver.masters.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `60`|
-| `puppetserver.masters.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `30`|
+| `puppetserver.masters.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `20`|
 | `puppetserver.masters.readinessProbeFailureThreshold` | the failure threshold for the puppetserver masters readiness probe | `3`|
 | `puppetserver.masters.readinessProbeSuccessThreshold` | the success threshold for the puppetserver masters readiness probe | `1`|
 | `puppetserver.masters.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `420`|
 | `puppetserver.masters.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `30`|
-| `puppetserver.masters.livenessProbeTimeout` | the timeout for the puppetserver masters liveness probe  | `30`|
+| `puppetserver.masters.livenessProbeTimeout` | the timeout for the puppetserver masters liveness probe  | `10`|
 | `puppetserver.masters.livenessProbeFailureThreshold` | the failure threshold for the puppetserver masters liveness probe | `3`|
 | `puppetserver.masters.livenessProbeSuccessThreshold` | the success threshold for the puppetserver masters liveness probe | `1`|
 | `puppetserver.masters.fqdns.alternateServerNames` | puppetserver masters alternate fqdns |``|
@@ -159,7 +159,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.compilers.extraEnv` | puppetserver compilers additional container env vars |``|
 | `puppetserver.compilers.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
 | `puppetserver.compilers.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `60`|
-| `puppetserver.compilers.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `10`|
+| `puppetserver.compilers.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `20`|
 | `puppetserver.compilers.readinessProbeFailureThreshold` | the failure threshold for the puppetserver masters readiness probe | `3`|
 | `puppetserver.compilers.readinessProbeSuccessThreshold` | the success threshold for the puppetserver masters readiness probe | `1`|
 | `puppetserver.compilers.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `420`|

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ docker run -dit --network host --name buggy_xtigyro --entrypoint /bin/bash puppe
 docker exec -it buggy_xtigyro bash
 puppet agent -t --server puppet-compilers --ca_server agents-to-puppet --masterport 8141 --ca_port 8140 --test --certname ubuntu-buggy_xtigyro
 puppet agent -t --server puppet-compilers --masterport 8141 --test --certname ubuntu-buggy_xtigyro
+# if Ingress is used, e.g.
+# puppet agent -t --server puppet.local.compilers --ca_server puppet.local.masters --masterport 443 --ca_port 443 --test --certname ubuntu-buggy_xtigyro
 puppet agent -t --server puppet --masterport 8140 --test --waitforcert 15 --certname ubuntu-buggy_xtigyro
 exit
 docker rm -f buggy_xtigyro

--- a/README.md
+++ b/README.md
@@ -308,6 +308,6 @@ kill %[job_numbers_above]
 
 * [Miroslav Hadzhiev](https://www.linkedin.com/in/mehadzhiev/), Lead Author and Developer
 * [Pupperware Team](mailto:pupperware@puppet.com), Owner
-* [Sean Conley](mailto:slconley@gmail.com), Developer
+* [Sean Conley](https://www.linkedin.com/in/seanconley/), Developer
 * [Morgan Rhodes](mailto:morgan@puppet.com), Developer
 * [Scott Cressi](mailto:scottcressi@gmail.com), Co-Author

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
 | `puppetserver.masters.resources` | puppetserver masters resource limits | ``|
 | `puppetserver.masters.extraEnv` | puppetserver masters additional container env vars |``|
-| `puppetserver.masters.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `120`|
-| `puppetserver.masters.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `30`|
+| `puppetserver.masters.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
+| `puppetserver.masters.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `60`|
 | `puppetserver.masters.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `30`|
 | `puppetserver.masters.readinessProbeFailureThreshold` | the failure threshold for the puppetserver masters readiness probe | `3`|
 | `puppetserver.masters.readinessProbeSuccessThreshold` | the success threshold for the puppetserver masters readiness probe | `1`|
-| `puppetserver.masters.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `150`|
-| `puppetserver.masters.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `20`|
+| `puppetserver.masters.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `420`|
+| `puppetserver.masters.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `30`|
 | `puppetserver.masters.livenessProbeTimeout` | the timeout for the puppetserver masters liveness probe  | `30`|
 | `puppetserver.masters.livenessProbeFailureThreshold` | the failure threshold for the puppetserver masters liveness probe | `3`|
 | `puppetserver.masters.livenessProbeSuccessThreshold` | the success threshold for the puppetserver masters liveness probe | `1`|
@@ -157,13 +157,13 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.compilers.podAntiAffinity` | puppetserver compilers pod affinity constraints |`false`|
 | `puppetserver.compilers.annotations`| puppetserver compilers statefulset annotations |``|
 | `puppetserver.compilers.extraEnv` | puppetserver compilers additional container env vars |``|
-| `puppetserver.compilers.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `120`|
-| `puppetserver.compilers.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `30`|
+| `puppetserver.compilers.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
+| `puppetserver.compilers.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `60`|
 | `puppetserver.compilers.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `10`|
 | `puppetserver.compilers.readinessProbeFailureThreshold` | the failure threshold for the puppetserver masters readiness probe | `3`|
 | `puppetserver.compilers.readinessProbeSuccessThreshold` | the success threshold for the puppetserver masters readiness probe | `1`|
-| `puppetserver.compilers.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `150`|
-| `puppetserver.compilers.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `20`|
+| `puppetserver.compilers.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `420`|
+| `puppetserver.compilers.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `30`|
 | `puppetserver.compilers.livenessProbeTimeout` | the timeout for the puppetserver masters liveness probe  | `10`|
 | `puppetserver.compilers.livenessProbeFailureThreshold` | the failure threshold for the puppetserver masters liveness probe | `3`|
 | `puppetserver.compilers.livenessProbeSuccessThreshold` | the success threshold for the puppetserver masters liveness probe | `1`|

--- a/README.md
+++ b/README.md
@@ -310,4 +310,4 @@ kill %[job_numbers_above]
 * [Pupperware Team](mailto:pupperware@puppet.com), Owner
 * [Sean Conley](mailto:slconley@gmail.com), Developer
 * [Morgan Rhodes](mailto:morgan@puppet.com), Developer
-* [Scott Cressi](mailto:scottcressi@gmail.com), Developer
+* [Scott Cressi](mailto:scottcressi@gmail.com), Co-Author

--- a/README.md
+++ b/README.md
@@ -114,119 +114,139 @@ horizontalpodautoscaler.autoscaling/puppetserver-compilers-autoscaler   Stateful
 
 The following table lists the configurable parameters of the Puppetserver chart and their default values.
 
-Parameter | Description | Default
---------- | ----------- | -------
-`puppetserver.name` | puppetserver component label | `puppetserver`
-`puppetserver.image` | puppetserver image | `puppet/puppetserver`
-`puppetserver.tag` | puppetserver img tag | `6.10.0`
-`puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`
-`puppetserver.masters.resources` | puppetserver masters resource limits | ``
-`puppetserver.masters.extraEnv` | puppetserver masters additional container env vars |``
-`puppetserver.masters.fqdns.alternateServerNames` | puppetserver masters alternate fqdns |``
-`puppetserver.masters.service.type` | puppetserver masters svc type | `ClusterIP`
-`puppetserver.masters.service.ports` | puppetserver masters svc exposed ports | `puppetserver`
-`puppetserver.masters.service.annotations`| puppetserver masters svc annotations |``
-`puppetserver.masters.service.labels`| puppetserver additional masters svc labels |``
-`puppetserver.masters.service.loadBalancerIP`| puppetserver masters svc loadbalancer ip |``
-`puppetserver.masters.ingress.enabled`| puppetserver masters ingress creation enabled |`false`
-`puppetserver.masters.ingress.annotations`| puppetserver masters ingress annotations |``
-`puppetserver.masters.ingress.extraLabels`| puppetserver masters ingress extraLabels |``
-`puppetserver.masters.ingress.hosts`| puppetserver masters ingress hostnames |``
-`puppetserver.masters.ingress.tls`| puppetserver masters ingress tls configuration |``
-`puppetserver.masters.multiMasters.enabled` | If true, creates multiple Puppetserver masters | `false`
-`puppetserver.masters.multiMasters.manualScaling.masters` | If multiple masters are enabled, this field sets masters count | `1`
-`puppetserver.masters.multiMasters.autoScaling.enabled` | If true, creates masters Horizontal Pod Autoscaler | `false`
-`puppetserver.masters.multiMasters.autoScaling.minMasters` | If masters autoscaling enabled, this field sets minimum masters count | `1`
-`puppetserver.masters.multiMasters.autoScaling.maxMasters` | If masters autoscaling enabled, this field sets maximum masters count | `3`
-`puppetserver.masters.multiMasters.autoScaling.cpuUtilizationPercentage` | Target masters CPU utilization percentage to scale | `75`
-`puppetserver.masters.multiMasters.autoScaling.memoryUtilizationPercentage` | Target masters memory utilization percentage to scale | `75`
-`puppetserver.compilers.enabled` | If true, creates Puppetserver compilers | `false`
-`puppetserver.compilers.resources` | puppetserver compilers resource limits |``
-`puppetserver.compilers.podAntiAffinity` | puppetserver compilers pod affinity constraints |`false`
-`puppetserver.compilers.annotations`| puppetserver compilers statefulset annotations |``
-`puppetserver.compilers.extraEnv` | puppetserver compilers additional container env vars |``
-`puppetserver.compilers.manualScaling.compilers` | If multiple compilers are enabled, this field sets compiler count | `1`
-`puppetserver.compilers.autoScaling.enabled` | If true, creates compilers Horizontal Pod Autoscaler | `false`
-`puppetserver.compilers.autoScaling.minCompilers` | If autoscaling enabled, this field sets minimum compiler count | `1`
-`puppetserver.compilers.autoScaling.maxCompilers` | If compilers autoscaling enabled, this field sets maximum compiler count | `3`
-`puppetserver.compilers.autoScaling.cpuUtilizationPercentage` | Target compilers CPU utilization percentage to scale | `75`
-`puppetserver.compilers.autoScaling.memoryUtilizationPercentage` | Target compilers memory utilization percentage to scale | `75`
-`puppetserver.compilers.podManagementPolicy` | puppetserver compilers statefulset pod management policy | `OrderedReady`
-`puppetserver.compilers.fqdns.alternateServerNames` | puppetserver compilers alternate fqdns |``
-`puppetserver.compilers.service.type` | puppetserver compilers svc type | `ClusterIP`
-`puppetserver.compilers.service.ports` | puppetserver compilers svc exposed ports | `puppetserver`
-`puppetserver.compilers.service.annotations`| puppetserver compilers svc annotations |``
-`puppetserver.compilers.service.labels`| puppetserver compilers additional svc labels |``
-`puppetserver.compilers.service.loadBalancerIP`| puppetserver compilers svc loadbalancer ip |``
-`puppetserver.compilers.service.headless.ports`| puppetserver compilers headless svc loadbalancer ip |`https`
-`puppetserver.compilers.service.headless.annotations`| puppetserver compilers headless svc annotations |``
-`puppetserver.compilers.service.headless.labels`| puppetserver compilers additional headless svc labels |``
-`puppetserver.compilers.ingress.enabled`| puppetserver compilers ingress creation enabled |`false`
-`puppetserver.compilers.ingress.annotations`| puppetserver compilers ingress annotations |``
-`puppetserver.compilers.ingress.extraLabels`| puppetserver compilers ingress extraLabels |``
-`puppetserver.compilers.ingress.hosts`| puppetserver compilers ingress hostnames |``
-`puppetserver.compilers.ingress.tls`| puppetserver compilers ingress tls configuration |``
-`puppetserver.preGeneratedCertsJob.enabled` | puppetserver pre-generated certs |`false`
-`puppetserver.preGeneratedCertsJob.jobDeadline` | puppetserver pre-generated certs job deadline in seconds |`60`
-`puppetserver.puppeturl`| puppetserver control repo url |``
-`r10k.name` | r10k component label | `r10k`
-`r10k.image` | r10k img | `puppet/r10k`
-`r10k.tag` | r10k img tag | `3.5.1`
-`r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`
-`r10k.code.resources` | r10k control repo resource limits |``
-`r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`
-`r10k.code.extraArgs` | r10k control repo additional container env args |``
-`r10k.code.extraEnv` | r10k control repo additional container env vars |``
-`r10k.code.viaSsh.credentials.ssh.value`| r10k control repo ssh key file |``
-`r10k.code.viaSsh.credentials.known_hosts.value`| r10k control repo ssh known hosts file |``
-`r10k.code.viaSsh.credentials.existingSecret`| r10k control repo ssh secret that holds ssh key and known hosts files |``
-`r10k.hiera.resources` | r10k hiera data resource limits |``
-`r10k.hiera.cronJob.schedule` | r10k hiera data cron job schedule policy | `*/2 * * * *`
-`r10k.hiera.extraArgs` | r10k hiera data additional container env args |``
-`r10k.hiera.extraEnv` | r10k hiera data additional container env vars |``
-`r10k.hiera.viaSsh.credentials.ssh.value`| r10k hiera data ssh key file |``
-`r10k.hiera.viaSsh.credentials.known_hosts.value`| r10k hiera data ssh known hosts file |``
-`r10k.hiera.viaSsh.credentials.existingSecret`| r10k hiera data ssh secret that holds ssh key and known hosts files |``
-`postgres.name` | postgres component label | `postgres`
-`postgres.image` | postgres img | `postgres`
-`postgres.tag` | postgres img tag | `9.6.18`
-`postgres.pullPolicy` | postgres img pull policy | `IfNotPresent`
-`postgres.resources` | postgres resource limits |``
-`postgres.extraEnv` | postgres additional container env vars |``
-`puppetdb.name` | puppetdb component label | `puppetdb`
-`puppetdb.image` | puppetdb img | `puppet/puppetdb`
-`puppetdb.tag` | puppetdb img tag | `6.10.1`
-`puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`
-`puppetdb.resources` | puppetdb resource limits |``
-`puppetdb.extraEnv` | puppetdb additional container env vars |``
-`puppetdb.credentials.username`| puppetdb username |`puppetdb`
-`puppetdb.credentials.value.password`| puppetdb password |`20-char randomly generated`
-`puppetdb.credentials.existingSecret`| existing k8s secret that holds puppetdb username and password |``
-`puppetboard.enabled` | puppetboard availability | `false`
-`puppetboard.name` | puppetboard component label | `puppetboard`
-`puppetboard.image` | puppetboard img | `xtigyro/puppetboard`
-`puppetboard.tag` | puppetboard img tag | `2.1.2`
-`puppetboard.pullPolicy` | puppetboard img pull policy | `IfNotPresent`
-`puppetboard.resources` | puppetboard resource limits |``
-`puppetboard.extraEnv` | puppetboard additional container env vars |``
-`puppetboard.ingress.enabled`| puppetboard ingress creation enabled |`false`
-`puppetboard.ingress.annotations`| puppetboard ingress annotations |``
-`puppetboard.ingress.extraLabels`| puppetboard ingress extraLabels |``
-`puppetboard.ingress.hosts`| puppetboard ingress hostnames |``
-`puppetboard.ingress.tls`| puppetboard ingress tls configuration |``
-`hiera.name` | hiera component label | `hiera`
-`hiera.hieradataurl`| hieradata repo url |``
-`hiera.config`| hieradata yaml config |``
-`hiera.eyaml.private_key`| hiera eyaml private key |``
-`hiera.eyaml.public_key`| hiera eyaml public key |``
-`nodeSelector`| Node labels for pod assignment |``
-`affinity`| Affinity for pod assignment |``
-`tolerations`| Tolerations for pod assignment |``
-`priorityClass`| Leverage a priorityClass to ensure your pods survive resource shortages |``
-`podAnnotations`| Extra Pod annotations |``
-`storage.storageClass`| Storage Class |``
-`storage.annotations`| Storage annotations |``
-`storage.size`| PVCs Storage Size |`100Mi`
+| Parameter | Description | Default|
+| --------- | ----------- | -------|
+| `puppetserver.name` | puppetserver component label | `puppetserver`|
+| `puppetserver.image` | puppetserver image | `puppet/puppetserver`|
+| `puppetserver.tag` | puppetserver img tag | `6.10.0`|
+| `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
+| `puppetserver.masters.resources` | puppetserver masters resource limits | ``|
+| `puppetserver.masters.extraEnv` | puppetserver masters additional container env vars |``|
+| `puppetserver.masters.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `120`|
+| `puppetserver.masters.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `30`|
+| `puppetserver.masters.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `30`|
+| `puppetserver.masters.readinessProbeFailureThreshold` | the failure threshold for the puppetserver masters readiness probe | `3`|
+| `puppetserver.masters.readinessProbeSuccessThreshold` | the success threshold for the puppetserver masters readiness probe | `1`|
+| `puppetserver.masters.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `150`|
+| `puppetserver.masters.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `20`|
+| `puppetserver.masters.livenessProbeTimeout` | the timeout for the puppetserver masters liveness probe  | `30`|
+| `puppetserver.masters.livenessProbeFailureThreshold` | the failure threshold for the puppetserver masters liveness probe | `3`|
+| `puppetserver.masters.livenessProbeSuccessThreshold` | the success threshold for the puppetserver masters liveness probe | `1`|
+| `puppetserver.masters.fqdns.alternateServerNames` | puppetserver masters alternate fqdns |``|
+| `puppetserver.masters.service.type` | puppetserver masters svc type | `ClusterIP`|
+| `puppetserver.masters.service.ports` | puppetserver masters svc exposed ports | `puppetserver`|
+| `puppetserver.masters.service.annotations`| puppetserver masters svc annotations |``|
+| `puppetserver.masters.service.labels`| puppetserver additional masters svc labels |``|
+| `puppetserver.masters.service.loadBalancerIP`| puppetserver masters svc loadbalancer ip |``|
+| `puppetserver.masters.ingress.enabled`| puppetserver masters ingress creation enabled |`false`|
+| `puppetserver.masters.ingress.annotations`| puppetserver masters ingress annotations |``|
+| `puppetserver.masters.ingress.extraLabels`| puppetserver masters ingress extraLabels |``|
+| `puppetserver.masters.ingress.hosts`| puppetserver masters ingress hostnames |``|
+| `puppetserver.masters.ingress.tls`| puppetserver masters ingress tls configuration |``|
+| `puppetserver.masters.multiMasters.enabled` | If true, creates multiple Puppetserver masters | `false`|
+| `puppetserver.masters.multiMasters.manualScaling.masters` | If multiple masters are enabled, this field sets masters count | `1`|
+| `puppetserver.masters.multiMasters.autoScaling.enabled` | If true, creates masters Horizontal Pod Autoscaler | `false`|
+| `puppetserver.masters.multiMasters.autoScaling.minMasters` | If masters autoscaling enabled, this field sets minimum masters count | `1`|
+| `puppetserver.masters.multiMasters.autoScaling.maxMasters` | If masters autoscaling enabled, this field sets maximum masters count | `3`|
+| `puppetserver.masters.multiMasters.autoScaling.cpuUtilizationPercentage` | Target masters CPU utilization percentage to scale | `75`|
+| `puppetserver.masters.multiMasters.autoScaling.memoryUtilizationPercentage` | Target masters memory utilization percentage to scale | `75`|
+| `puppetserver.compilers.enabled` | If true, creates Puppetserver compilers | `false`|
+| `puppetserver.compilers.resources` | puppetserver compilers resource limits |``|
+| `puppetserver.compilers.podAntiAffinity` | puppetserver compilers pod affinity constraints |`false`|
+| `puppetserver.compilers.annotations`| puppetserver compilers statefulset annotations |``|
+| `puppetserver.compilers.extraEnv` | puppetserver compilers additional container env vars |``|
+| `puppetserver.compilers.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `120`|
+| `puppetserver.compilers.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `30`|
+| `puppetserver.compilers.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `10`|
+| `puppetserver.compilers.readinessProbeFailureThreshold` | the failure threshold for the puppetserver masters readiness probe | `3`|
+| `puppetserver.compilers.readinessProbeSuccessThreshold` | the success threshold for the puppetserver masters readiness probe | `1`|
+| `puppetserver.compilers.livenessProbeInitialDelay` | the initial delay for the puppetserver masters liveness probe | `150`|
+| `puppetserver.compilers.livenessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters liveness probe | `20`|
+| `puppetserver.compilers.livenessProbeTimeout` | the timeout for the puppetserver masters liveness probe  | `10`|
+| `puppetserver.compilers.livenessProbeFailureThreshold` | the failure threshold for the puppetserver masters liveness probe | `3`|
+| `puppetserver.compilers.livenessProbeSuccessThreshold` | the success threshold for the puppetserver masters liveness probe | `1`|
+| `puppetserver.compilers.manualScaling.compilers` | If multiple compilers are enabled, this field sets compiler count | `1`|
+| `puppetserver.compilers.autoScaling.enabled` | If true, creates compilers Horizontal Pod Autoscaler | `false`|
+| `puppetserver.compilers.autoScaling.minCompilers` | If autoscaling enabled, this field sets minimum compiler count | `1`|
+| `puppetserver.compilers.autoScaling.maxCompilers` | If compilers autoscaling enabled, this field sets maximum compiler count | `3`|
+| `puppetserver.compilers.autoScaling.cpuUtilizationPercentage` | Target compilers CPU utilization percentage to scale | `75`|
+| `puppetserver.compilers.autoScaling.memoryUtilizationPercentage` | Target compilers memory utilization percentage to scale | `75`|
+| `puppetserver.compilers.podManagementPolicy` | puppetserver compilers statefulset pod management policy | `OrderedReady`|
+| `puppetserver.compilers.fqdns.alternateServerNames` | puppetserver compilers alternate fqdns |``|
+| `puppetserver.compilers.service.type` | puppetserver compilers svc type | `ClusterIP`|
+| `puppetserver.compilers.service.ports` | puppetserver compilers svc exposed ports | `puppetserver`|
+| `puppetserver.compilers.service.annotations`| puppetserver compilers svc annotations |``|
+| `puppetserver.compilers.service.labels`| puppetserver compilers additional svc labels |``|
+| `puppetserver.compilers.service.loadBalancerIP`| puppetserver compilers svc loadbalancer ip |``|
+| `puppetserver.compilers.service.headless.ports`| puppetserver compilers headless svc loadbalancer ip |`https`|
+| `puppetserver.compilers.service.headless.annotations`| puppetserver compilers headless svc annotations |``|
+| `puppetserver.compilers.service.headless.labels`| puppetserver compilers additional headless svc labels |``|
+| `puppetserver.compilers.ingress.enabled`| puppetserver compilers ingress creation enabled |`false`|
+| `puppetserver.compilers.ingress.annotations`| puppetserver compilers ingress annotations |``|
+| `puppetserver.compilers.ingress.extraLabels`| puppetserver compilers ingress extraLabels |``|
+| `puppetserver.compilers.ingress.hosts`| puppetserver compilers ingress hostnames |``|
+| `puppetserver.compilers.ingress.tls`| puppetserver compilers ingress tls configuration |``|
+| `puppetserver.preGeneratedCertsJob.enabled` | puppetserver pre-generated certs |`false`|
+| `puppetserver.preGeneratedCertsJob.jobDeadline` | puppetserver pre-generated certs job deadline in seconds |`60`|
+| `puppetserver.puppeturl`| puppetserver control repo url |``|
+| `r10k.name` | r10k component label | `r10k`|
+| `r10k.image` | r10k img | `puppet/r10k`|
+| `r10k.tag` | r10k img tag | `3.5.1`|
+| `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`|
+| `r10k.code.resources` | r10k control repo resource limits |``|
+| `r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`|
+| `r10k.code.extraArgs` | r10k control repo additional container env args |``|
+| `r10k.code.extraEnv` | r10k control repo additional container env vars |``|
+| `r10k.code.viaSsh.credentials.ssh.value`| r10k control repo ssh key file |``|
+| `r10k.code.viaSsh.credentials.known_hosts.value`| r10k control repo ssh known hosts file |``|
+| `r10k.code.viaSsh.credentials.existingSecret`| r10k control repo ssh secret that holds ssh key and known hosts files |``|
+| `r10k.hiera.resources` | r10k hiera data resource limits |``|
+| `r10k.hiera.cronJob.schedule` | r10k hiera data cron job schedule policy | `*/2 * * * *`|
+| `r10k.hiera.extraArgs` | r10k hiera data additional container env args |``|
+| `r10k.hiera.extraEnv` | r10k hiera data additional container env vars |``|
+| `r10k.hiera.viaSsh.credentials.ssh.value`| r10k hiera data ssh key file |``|
+| `r10k.hiera.viaSsh.credentials.known_hosts.value`| r10k hiera data ssh known hosts file |``|
+| `r10k.hiera.viaSsh.credentials.existingSecret`| r10k hiera data ssh secret that holds ssh key and known hosts files |``|
+| `postgres.name` | postgres component label | `postgres`|
+| `postgres.image` | postgres img | `postgres`|
+| `postgres.tag` | postgres img tag | `9.6.18`|
+| `postgres.pullPolicy` | postgres img pull policy | `IfNotPresent`|
+| `postgres.resources` | postgres resource limits |``|
+| `postgres.extraEnv` | postgres additional container env vars |``|
+| `puppetdb.name` | puppetdb component label | `puppetdb`|
+| `puppetdb.image` | puppetdb img | `puppet/puppetdb`|
+| `puppetdb.tag` | puppetdb img tag | `6.10.1`|
+| `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`|
+| `puppetdb.resources` | puppetdb resource limits |``|
+| `puppetdb.extraEnv` | puppetdb additional container env vars |``|
+| `puppetdb.credentials.username`| puppetdb username |`puppetdb`|
+| `puppetdb.credentials.value.password`| puppetdb password |`20-char randomly generated`|
+| `puppetdb.credentials.existingSecret`| existing k8s secret that holds puppetdb username and password |``|
+| `puppetboard.enabled` | puppetboard availability | `false`|
+| `puppetboard.name` | puppetboard component label | `puppetboard`|
+| `puppetboard.image` | puppetboard img | `xtigyro/puppetboard`|
+| `puppetboard.tag` | puppetboard img tag | `2.1.2`|
+| `puppetboard.pullPolicy` | puppetboard img pull policy | `IfNotPresent`|
+| `puppetboard.resources` | puppetboard resource limits |``|
+| `puppetboard.extraEnv` | puppetboard additional container env vars |``|
+| `puppetboard.ingress.enabled`| puppetboard ingress creation enabled |`false`|
+| `puppetboard.ingress.annotations`| puppetboard ingress annotations |``|
+| `puppetboard.ingress.extraLabels`| puppetboard ingress extraLabels |``|
+| `puppetboard.ingress.hosts`| puppetboard ingress hostnames |``|
+| `puppetboard.ingress.tls`| puppetboard ingress tls configuration |``|
+| `hiera.name` | hiera component label | `hiera`|
+| `hiera.hieradataurl`| hieradata repo url |``|
+| `hiera.config`| hieradata yaml config |``|
+| `hiera.eyaml.private_key`| hiera eyaml private key |``|
+| `hiera.eyaml.public_key`| hiera eyaml public key |``|
+| `nodeSelector`| Node labels for pod assignment |``|
+| `affinity`| Affinity for pod assignment |``|
+| `tolerations`| Tolerations for pod assignment |``|
+| `priorityClass`| Leverage a priorityClass to ensure your pods survive resource shortages |``|
+| `podAnnotations`| Extra Pod annotations |``|
+| `storage.storageClass`| Storage Class |``|
+| `storage.annotations`| Storage annotations |``|
+| `storage.size`| PVCs Storage Size |`100Mi`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ kubectl port-forward -n puppetserver svc/puppet-compilers 8141:8140 &
 TIME_NOW="$(date +"%Y%m%dT%H%M")"
 cp "/etc/hosts"{,.backup_"$TIME_NOW"}
 echo '127.0.0.1 puppet agents-to-puppet puppet-compilers' >> /etc/hosts
+# if Ingress is used, e.g.
+# echo '127.0.0.1 puppet.local.masters puppet.local.compilers' >> /etc/hosts
 
 docker run -dit --network host --name goofy_xtigyro --entrypoint /bin/bash puppet/puppet-agent
 docker exec -it goofy_xtigyro bash

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ $ kubectl get --namespace puppetserver all -l release=puppetserver
 NAME                                                     READY   STATUS    RESTARTS   AGE
 pod/puppetserver-postgres-fc66cbc49-d5pl7                1/1     Running   0          7m17s
 pod/puppetserver-puppetdb-56498d68dc-8c54g               2/2     Running   0          7m17s
-pod/puppetserver-puppetserver-compilers-0                3/3     Running   0          7m17s
-pod/puppetserver-puppetserver-masters-5c6dbdc78f-8xf6x   3/3     Running   0          7m17s
+pod/puppetserver-puppetserver-compiler-0                 3/3     Running   0          7m17s
+pod/puppetserver-puppetserver-master-5c6dbdc78f-8xf6x    3/3     Running   0          7m17s
 
 NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                    AGE
 service/agents-to-puppet            ClusterIP   10.104.117.137   <none>        8140/TCP                   7m17s
@@ -98,15 +98,15 @@ service/puppetdb                    ClusterIP   10.111.63.231    <none>        8
 NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/puppetserver-postgres               1/1     1            1           7m17s
 deployment.apps/puppetserver-puppetdb               1/1     1            1           7m17s
-deployment.apps/puppetserver-puppetserver-masters   1/1     1            1           7m17s
+deployment.apps/puppetserver-puppetserver-master    1/1     1            1           7m17s
 
 NAME                                                           DESIRED   CURRENT   READY   AGE
 replicaset.apps/puppetserver-postgres-fc66cbc49                1         1         1       7m17s
 replicaset.apps/puppetserver-puppetdb-56498d68dc               1         1         1       7m17s
-replicaset.apps/puppetserver-puppetserver-masters-5c6dbdc78f   1         1         1       7m17s
+replicaset.apps/puppetserver-puppetserver-master-5c6dbdc78f    1         1         1       7m17s
 
 NAME                                                   READY   AGE
-statefulset.apps/puppetserver-puppetserver-compilers   1/1     7m17s
+statefulset.apps/puppetserver-puppetserver-compiler   1/1     7m17s
 
 NAME                                                                    REFERENCE                                         TARGETS            MINPODS   MAXPODS   REPLICAS   AGE
 horizontalpodautoscaler.autoscaling/puppetserver-compilers-autoscaler   StatefulSet/puppetserver-puppetserver-compilers   43%/75%, 67%/75%   1         3         1          7m17s

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -200,7 +200,7 @@ Calculates the max. number of compilers
 {{- define "puppetserver.compilers.hostnames" -}}
   {{- $dot := . -}}
   {{- range $compilersLoopCount, $e := until ((include "puppetserver.compilers.maxNo" $dot) | int) -}}
-    {{- printf "%s-puppetserver-compilers-%d" (include "puppetserver.name" $dot) $compilersLoopCount -}}
+    {{- printf "%s-puppetserver-compiler-%d" (include "puppetserver.name" $dot) $compilersLoopCount -}}
     {{- if lt $compilersLoopCount  ( sub ((include "puppetserver.compilers.maxNo" $dot) | int) 1 ) -}}
       {{- printf "," -}}
     {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -166,6 +166,20 @@ puppet-compilers
 {{- end -}}
 
 {{/*
+Puppet Masters' port.
+*/}}
+{{- define "puppetserver.puppetserver-masters.port" -}}
+{{- .Values.puppetserver.masters.service.ports.puppetserver.port -}}
+{{- end -}}
+
+{{/*
+Puppet Compilers' port.
+*/}}
+{{- define "puppetserver.puppetserver-compilers.port" -}}
+{{- .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
+{{- end -}}
+
+{{/*
 Set's the affinity for pod placement
 when running with multiple Puppet compilers.
 */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -169,14 +169,22 @@ puppet-compilers
 Puppet Masters' port.
 */}}
 {{- define "puppetserver.puppetserver-masters.port" -}}
+{{- if .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 {{- .Values.puppetserver.masters.service.ports.puppetserver.port -}}
+{{- else -}}
+8140
+{{- end -}}
 {{- end -}}
 
 {{/*
 Puppet Compilers' port.
 */}}
 {{- define "puppetserver.puppetserver-compilers.port" -}}
+{{- if .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
 {{- .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
+{{- else -}}
+8140
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $puppetserverMastersServicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,6 +34,8 @@ spec:
             {{- end }}
             - name: PUPPETSERVER_HOSTNAME
               value: "puppet"
+            - name: PUPPETSERVER_PORT
+              value: {{ $puppetserverMastersServicePort }}
             - name: PUPPETDB_POSTGRES_HOSTNAME
               value: "postgres"
             - name: PUPPETDB_PASSWORD

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -1,4 +1,3 @@
-{{- $puppetserverMastersServicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,7 +34,7 @@ spec:
             - name: PUPPETSERVER_HOSTNAME
               value: "puppet"
             - name: PUPPETSERVER_PORT
-              value: "{{ $puppetserverMastersServicePort }}"
+              value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: PUPPETDB_POSTGRES_HOSTNAME
               value: "postgres"
             - name: PUPPETDB_PASSWORD

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: PUPPETSERVER_HOSTNAME
               value: "puppet"
             - name: PUPPETSERVER_PORT
-              value: {{ $puppetserverMastersServicePort }}
+              value: "{{ $puppetserverMastersServicePort }}"
             - name: PUPPETDB_POSTGRES_HOSTNAME
               value: "postgres"
             - name: PUPPETDB_PASSWORD

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -162,7 +162,7 @@ spec:
             # puppetserver ca cli application
             - name: PUPPETSERVER_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
-            - name: PUPPETSERVER_PORT
+            - name: PUPPET_MASTERPORT
               value: "{{ $puppetserverMastersServicePort }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.compilers.hostnames" . }},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{ template "puppetserver.puppetserver.agents-to-masters.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}},{{.Values.puppetserver.masters.fqdns.alternateServerNames}}"

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -17,8 +17,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: 20%
+      maxUnavailable: 0%
   template:
     metadata:
       labels:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -169,20 +169,22 @@ spec:
               value: "true"
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /status/v1/simple
               port: 8140
-            initialDelaySeconds: {{ .Values.puppetserver.readinessProbeInitialDelay }}
-            timeoutSeconds: {{ .Values.puppetserver.readinessProbeTimeout }}
-            failureThreshold: {{ .Values.puppetserver.readinessProbeFailureThreshold }}
-            successThreshold: {{ .Values.puppetserver.readinessProbeSuccessThreshold }}
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.puppetserver.masters.readinessProbeInitialDelay }}
+            periodSeconds: {{ .Values.puppetserver.masters.readinessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.puppetserver.masters.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.puppetserver.masters.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.puppetserver.masters.readinessProbeSuccessThreshold }}
           livenessProbe:
-            httpGet:
-              path: /healthy
+            tcpSocket:
               port: 8140
-            initialDelaySeconds: {{ .Values.puppetserver.livenessProbeInitialDelay }}
-            timeoutSeconds: {{ .Values.puppetserver.livenessProbeTimeout }}
-            failureThreshold: {{ .Values.puppetserver.livenessProbeFailureThreshold }}
-            successThreshold: {{ .Values.puppetserver.livenessProbeSuccessThreshold }}
+            initialDelaySeconds: {{ .Values.puppetserver.masters.livenessProbeInitialDelay }}
+            periodSeconds: {{ .Values.puppetserver.masters.livenessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.puppetserver.masters.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.puppetserver.masters.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.puppetserver.masters.livenessProbeSuccessThreshold }}
           ports:
             - containerPort: 8140
           volumeMounts:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -163,7 +163,7 @@ spec:
             - name: PUPPETSERVER_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
             - name: PUPPETSERVER_PORT
-              value: {{ $puppetserverMastersServicePort }}
+              value: "{{ $puppetserverMastersServicePort }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.compilers.hostnames" . }},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{ template "puppetserver.puppetserver.agents-to-masters.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}},{{.Values.puppetserver.masters.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "puppetserver.name" . }}-puppetserver-masters
+  name: {{ template "puppetserver.name" . }}-puppetserver-master
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
 spec:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -1,3 +1,4 @@
+{{- $puppetserverMastersServicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -161,6 +162,8 @@ spec:
             # puppetserver ca cli application
             - name: PUPPETSERVER_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
+            - name: PUPPETSERVER_PORT
+              value: {{ $puppetserverMastersServicePort }}
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.compilers.hostnames" . }},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{ template "puppetserver.puppetserver.agents-to-masters.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}},{{.Values.puppetserver.masters.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -167,6 +167,22 @@ spec:
               value: "https://puppetdb:8081"
             - name: CA_ALLOW_SUBJECT_ALT_NAMES
               value: "true"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8140
+            initialDelaySeconds: {{ .Values.puppetserver.readinessProbeInitialDelay }}
+            timeoutSeconds: {{ .Values.puppetserver.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.puppetserver.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.puppetserver.readinessProbeSuccessThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8140
+            initialDelaySeconds: {{ .Values.puppetserver.livenessProbeInitialDelay }}
+            timeoutSeconds: {{ .Values.puppetserver.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.puppetserver.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.puppetserver.livenessProbeSuccessThreshold }}
           ports:
             - containerPort: 8140
           volumeMounts:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -1,4 +1,3 @@
-{{- $puppetserverMastersServicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -163,7 +162,7 @@ spec:
             - name: PUPPETSERVER_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
             - name: PUPPET_MASTERPORT
-              value: "{{ $puppetserverMastersServicePort }}"
+              value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.compilers.hostnames" . }},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{ template "puppetserver.puppetserver.agents-to-masters.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}},{{.Values.puppetserver.masters.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS
@@ -173,7 +172,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /status/v1/simple
-              port: {{ $puppetserverMastersServicePort}}
+              port: {{ template "puppetserver.puppetserver-masters.port" .}}
               scheme: HTTPS
             initialDelaySeconds: {{ .Values.puppetserver.masters.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.masters.readinessProbePeriodSeconds }}
@@ -182,14 +181,14 @@ spec:
             successThreshold: {{ .Values.puppetserver.masters.readinessProbeSuccessThreshold }}
           livenessProbe:
             tcpSocket:
-              port: {{ $puppetserverMastersServicePort}}
+              port: {{ template "puppetserver.puppetserver-masters.port" .}}
             initialDelaySeconds: {{ .Values.puppetserver.masters.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.masters.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.masters.livenessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.masters.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.puppetserver.masters.livenessProbeSuccessThreshold }}
           ports:
-            - containerPort: {{ $puppetserverMastersServicePort}}
+            - containerPort: {{ template "puppetserver.puppetserver-masters.port" .}}
           volumeMounts:
             - name: puppet-code-storage
               mountPath: /etc/puppetlabs/code/

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -173,7 +173,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /status/v1/simple
-              port: 8140
+              port: {{ $puppetserverMastersServicePort}}
               scheme: HTTPS
             initialDelaySeconds: {{ .Values.puppetserver.masters.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.masters.readinessProbePeriodSeconds }}
@@ -182,14 +182,14 @@ spec:
             successThreshold: {{ .Values.puppetserver.masters.readinessProbeSuccessThreshold }}
           livenessProbe:
             tcpSocket:
-              port: 8140
+              port: {{ $puppetserverMastersServicePort}}
             initialDelaySeconds: {{ .Values.puppetserver.masters.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.masters.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.masters.livenessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.masters.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.puppetserver.masters.livenessProbeSuccessThreshold }}
           ports:
-            - containerPort: 8140
+            - containerPort: {{ $puppetserverMastersServicePort}}
           volumeMounts:
             - name: puppet-code-storage
               mountPath: /etc/puppetlabs/code/

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -1,3 +1,4 @@
+{{- $puppetserverCompilersServicePort := .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
 {{- if .Values.puppetserver.compilers.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -144,6 +145,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: PUPPETSERVER_PORT
+              value: {{ $puppetserverCompilersServicePort }}
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "puppetserver.name" . }}-puppetserver-compilers
+  name: {{ template "puppetserver.name" . }}-puppetserver-compiler
   labels:
     {{- include "puppetserver.puppetserver-compilers.labels" . | nindent 4 }}
   {{- if .Values.puppetserver.compilers.annotations }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -1,5 +1,3 @@
-{{- $puppetserverCompilersServicePort := .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
-{{- $puppetserverMastersServicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 {{- if .Values.puppetserver.compilers.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -149,7 +147,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: PUPPET_MASTERPORT
-              value: "{{ $puppetserverCompilersServicePort }}"
+              value: "{{ template "puppetserver.puppetserver-compilers.port" . }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS
@@ -159,11 +157,11 @@ spec:
             - name: CA_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
             - name: CA_MASTERPORT
-              value: "{{ $puppetserverMastersServicePort }}"
+              value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
           readinessProbe:
             httpGet:
               path: /status/v1/simple
-              port: {{ $puppetserverCompilersServicePort }}
+              port: {{ template "puppetserver.puppetserver-compilers.port" . }}
               scheme: HTTPS
             initialDelaySeconds: {{ .Values.puppetserver.compilers.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.compilers.readinessProbePeriodSeconds }}
@@ -172,14 +170,14 @@ spec:
             successThreshold: {{ .Values.puppetserver.compilers.readinessProbeSuccessThreshold }}
           livenessProbe:
             tcpSocket:
-              port: {{ $puppetserverCompilersServicePort }}
+              port: {{ template "puppetserver.puppetserver-compilers.port" . }}
             initialDelaySeconds: {{ .Values.puppetserver.compilers.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.compilers.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.compilers.livenessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.compilers.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.puppetserver.compilers.livenessProbeSuccessThreshold }}
           ports:
-            - containerPort: {{ $puppetserverCompilersServicePort }}
+            - containerPort: {{ template "puppetserver.puppetserver-compilers.port" . }}
           volumeMounts:
             - name: puppet-code-volume
               mountPath: /etc/puppetlabs/code/

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -146,7 +146,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: PUPPETSERVER_PORT
-              value: {{ $puppetserverCompilersServicePort }}
+              value: "{{ $puppetserverCompilersServicePort }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -20,6 +20,8 @@ spec:
   replicas: {{ .Values.puppetserver.compilers.manualScaling.compilers }}
   {{- end }}
   podManagementPolicy: {{ .Values.puppetserver.compilers.podManagementPolicy }}
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -158,7 +158,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /status/v1/simple
-              port: 8140
+              port: {{ $puppetserverCompilersServicePort }}
               scheme: HTTPS
             initialDelaySeconds: {{ .Values.puppetserver.compilers.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.compilers.readinessProbePeriodSeconds }}
@@ -167,14 +167,14 @@ spec:
             successThreshold: {{ .Values.puppetserver.compilers.readinessProbeSuccessThreshold }}
           livenessProbe:
             tcpSocket:
-              port: 8140
+              port: {{ $puppetserverCompilersServicePort }}
             initialDelaySeconds: {{ .Values.puppetserver.compilers.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.compilers.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.compilers.livenessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.compilers.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.puppetserver.compilers.livenessProbeSuccessThreshold }}
           ports:
-            - containerPort: 8140
+            - containerPort: {{ $puppetserverCompilersServicePort }}
           volumeMounts:
             - name: puppet-code-volume
               mountPath: /etc/puppetlabs/code/

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -1,4 +1,5 @@
 {{- $puppetserverCompilersServicePort := .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
+{{- $puppetserverMastersServicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
 {{- if .Values.puppetserver.compilers.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -145,7 +146,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: PUPPETSERVER_PORT
+            - name: PUPPET_MASTERPORT
               value: "{{ $puppetserverCompilersServicePort }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
@@ -155,6 +156,8 @@ spec:
               value: "false"
             - name: CA_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
+            - name: CA_MASTERPORT
+              value: "{{ $puppetserverMastersServicePort }}"
           readinessProbe:
             httpGet:
               path: /status/v1/simple

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -152,6 +152,24 @@ spec:
               value: "false"
             - name: CA_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
+          readinessProbe:
+            httpGet:
+              path: /status/v1/simple
+              port: 8140
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.puppetserver.compilers.readinessProbeInitialDelay }}
+            periodSeconds: {{ .Values.puppetserver.compilers.readinessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.puppetserver.compilers.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.puppetserver.compilers.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.puppetserver.compilers.readinessProbeSuccessThreshold }}
+          livenessProbe:
+            tcpSocket:
+              port: 8140
+            initialDelaySeconds: {{ .Values.puppetserver.compilers.livenessProbeInitialDelay }}
+            periodSeconds: {{ .Values.puppetserver.compilers.livenessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.puppetserver.compilers.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.puppetserver.compilers.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.puppetserver.compilers.livenessProbeSuccessThreshold }}
           ports:
             - containerPort: 8140
           volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -237,7 +237,7 @@ r10k:
           ## A multi-line string
           value:  # |
             #  KNOWN_HOSTS CONTENTS
-        ## Or set the git-sync Known Hosts file and SSH Private Key
+        ## or set the r10k known hosts file and SSH Private Key
         ## from a pre-existing K8s secret
         existingSecret: ""
   hiera:
@@ -267,7 +267,7 @@ r10k:
           ## A multi-line string
           value:  # |
             #  KNOWN_HOSTS CONTENTS
-        ## Or set the git-sync Known Hosts file and SSH Private Key
+        ## or set the r10k known hosts file and SSH Private Key
         ## from a pre-existing K8s secret
         existingSecret: ""
 

--- a/values.yaml
+++ b/values.yaml
@@ -61,9 +61,6 @@ puppetserver:
       ## The LB type (network protocol) for some cloud providers must be set here.
       ports:
         puppetserver:
-          ## WARNING: if a different port is set, PuppetDB and Puppet Compiler/s container images
-          ## must be modified - so that they can connect to Puppet Master/s K8s Service and vice versa.
-          ## Their Docker entrypoint scripts expect port "8140".
           port: 8140
         #  protocol: TCP
       ## Exemplary annotations for few cloud providers
@@ -204,9 +201,6 @@ puppetserver:
       ## The LB type (network protocol) for some cloud providers must be set here.
       ports:
         puppetserver:
-          ## WARNING: if a different port is set, PuppetDB and Puppet Master/s container images
-          ## must be modified - so that they can connect to Puppet Compilers/s K8s Service and vice versa.
-          ## Their Docker entrypoint scripts expect port "8140".
           port: 8140
         #  protocol: TCP
       ## Exemplary annotations for few cloud providers

--- a/values.yaml
+++ b/values.yaml
@@ -61,6 +61,9 @@ puppetserver:
       ## The LB type (network protocol) for some cloud providers must be set here.
       ports:
         puppetserver:
+          ## WARNING: if a different port is set, PuppetDB and Puppet Compiler/s container images
+          ## must be modified - so that they can connect to Puppet Master/s K8s Service and vice versa.
+          ## Their Docker entrypoint scripts expect port "8140".
           port: 8140
         #  protocol: TCP
       ## Exemplary annotations for few cloud providers
@@ -80,8 +83,8 @@ puppetserver:
       ## Puppet Server Masters Ingress annotations
       ##
       annotations: {}
-        # kubernetes.io/ingress.class: nginx
-        # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        #  kubernetes.io/ingress.class: nginx
+        #  nginx.ingress.kubernetes.io/ssl-passthrough: "true"
       ## Puppet Server Masters Ingress additional labels
       ##
       extraLabels: {}
@@ -201,6 +204,9 @@ puppetserver:
       ## The LB type (network protocol) for some cloud providers must be set here.
       ports:
         puppetserver:
+          ## WARNING: if a different port is set, PuppetDB and Puppet Master/s container images
+          ## must be modified - so that they can connect to Puppet Compilers/s K8s Service and vice versa.
+          ## Their Docker entrypoint scripts expect port "8140".
           port: 8140
         #  protocol: TCP
       ## Exemplary annotations for few cloud providers
@@ -229,8 +235,8 @@ puppetserver:
       ## Puppet Server Compilers Ingress annotations
       ##
       annotations: {}
-        # kubernetes.io/ingress.class: nginx
-        # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        #  kubernetes.io/ingress.class: nginx
+        #  nginx.ingress.kubernetes.io/ssl-passthrough: "true"
       ## Puppet Server Compilers Ingress additional labels
       ##
       extraLabels: {}
@@ -260,7 +266,7 @@ puppetserver:
   ## the management of configuration data from that of the Puppet code base.
   ## A separate Hieradata Repo can be included in the "hiera" section in this file.
   ##
-  puppeturl: ""   # git@github.com:$SOMEUSER/puppet.git
+  puppeturl: ""   #  git@github.com:$SOMEUSER/puppet.git
 
 ## r10k Repo Configuration
 ##
@@ -281,9 +287,9 @@ r10k:
       schedule: "*/15 * * * *"
     ## Additional r10k code container arguments
     extraArgs: {}
-    #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
-    #  - --trace
-    #  - --color
+    #   - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
+    #   - --trace
+    #   - --color
     ## Additional r10k code container environment variables
     extraEnv: {}
     viaSsh:
@@ -311,9 +317,9 @@ r10k:
       schedule: "*/2 * * * *"
     ## Additional r10k hiera container environment variables
     extraArgs: {}
-    #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
-    #  - --trace
-    #  - --color
+    #   - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
+    #   - --trace
+    #   - --color
     ## Additional puppetserver hiera container environment variables
     extraEnv: {}
     viaSsh:

--- a/values.yaml
+++ b/values.yaml
@@ -30,13 +30,13 @@ puppetserver:
     ## Puppet Server Master readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
-    readinessProbeInitialDelay: 120
-    readinessProbePeriodSeconds: 30
+    readinessProbeInitialDelay: 180
+    readinessProbePeriodSeconds: 60
     readinessProbeTimeout: 10
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
-    livenessProbeInitialDelay: 150
-    livenessProbePeriodSeconds: 20
+    livenessProbeInitialDelay: 420
+    livenessProbePeriodSeconds: 30
     livenessProbeTimeout: 10
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1
@@ -153,12 +153,12 @@ puppetserver:
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
     readinessProbeInitialDelay: 180
-    readinessProbePeriodSeconds: 30
+    readinessProbePeriodSeconds: 60
     readinessProbeTimeout: 30
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
     livenessProbeInitialDelay: 420
-    livenessProbePeriodSeconds: 20
+    livenessProbePeriodSeconds: 30
     livenessProbeTimeout: 30
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1

--- a/values.yaml
+++ b/values.yaml
@@ -9,8 +9,12 @@ puppetserver:
   image: puppet/puppetserver
   tag: 6.10.0
   pullPolicy: IfNotPresent
+  ## Mandatory Deployment of Puppet Server Master/s
+  ##
   masters:
-    ##
+  ## Puppet Server Master resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
     resources: {}
     #  requests:
     #    memory: 1024Mi
@@ -18,8 +22,23 @@ puppetserver:
     #  limits:
     #    memory: 1536Mi
     #    cpu: 1000m
+
     ## Additional Masters' container environment variables
+    ##
     extraEnv: {}
+
+    ## Puppet Server Master readiness and liveness probe initial delays and timeouts
+    ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+    ##
+    readinessProbeInitialDelay: 60
+    readinessProbeTimeout: 30
+    readinessProbeFailureThreshold: 3
+    readinessProbeSuccessThreshold: 1
+    livenessProbeInitialDelay: 90
+    livenessProbeTimeout: 30
+    livenessProbeFailureThreshold: 3
+    livenessProbeSuccessThreshold: 1
+
     ## Fully qualified domain names (FQDN's) to register
     ## the Puppet Server Masters to be internally reachable via DNS.
     ## That is necessary to configure "certname" and "server" in `puppet.conf`.
@@ -30,9 +49,11 @@ puppetserver:
     ##
     fqdns:
       alternateServerNames: ""   # Comma-separated
+
     ## Service for Puppet Server Masters
     ## The usage of a TCP/Network LB type is strongly preferable
     ## Please check the `README.md` for more information
+    ##
     service:
       type: ClusterIP
       ## The LB type (network protocol) for some cloud providers must be set here.
@@ -49,6 +70,7 @@ puppetserver:
       #  service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
       labels: {}
       loadBalancerIP: ""
+
     ingress:
       ## If true, Puppet Server Masters Ingress will be created
       ##
@@ -74,6 +96,7 @@ puppetserver:
       #   - secretName: puppet-server-tls
       #     hosts:
       #       - puppet.domain.com
+
     ## Horizontal Scaling
     ##
     multiMasters:
@@ -95,9 +118,14 @@ puppetserver:
         maxMasters: 3
         cpuUtilizationPercentage: 75
         memoryUtilizationPercentage: 75
-  ## Optional StatefulSet of Puppet Server Compilers
+
+  ## Optional StatefulSet of Puppet Server Compiler/s
+  ##
   compilers:
     enabled: false
+  ## Puppet Server Compiler resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
     resources: {}
     #  requests:
     #    memory: 1024Mi
@@ -105,15 +133,35 @@ puppetserver:
     #  limits:
     #    memory: 1536Mi
     #    cpu: 1000m
+
     ## Affinity for puppetserver pod assignment
     ## Schedule compilers on different K8s nodes
+    ##
     podAntiAffinity: false
+
     ## Puppetserver Compilers' StatefulSet annotations
+    ##
     annotations: {}
+
     ## Additional Compilers' container environment variables
+    ##
     extraEnv: {}
+
+    ## Puppet Server Compiler readiness and liveness probe initial delays and timeouts
+    ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+    ##
+    readinessProbeInitialDelay: 60
+    readinessProbeTimeout: 30
+    readinessProbeFailureThreshold: 3
+    readinessProbeSuccessThreshold: 1
+    livenessProbeInitialDelay: 90
+    livenessProbeTimeout: 30
+    livenessProbeFailureThreshold: 3
+    livenessProbeSuccessThreshold: 1
+
     ## Horizontal Pod Manual Scaling for Puppet Server Compilers
     ## Set the desired number of Puppet Server Compilers
+    ##
     manualScaling:
       compilers: 1
     ## Horizontal Pod Autoscaling for Puppet Server Compilers
@@ -128,6 +176,7 @@ puppetserver:
       cpuUtilizationPercentage: 75
       memoryUtilizationPercentage: 75
     podManagementPolicy: OrderedReady
+
     ## Fully qualified domain names (FQDN's) to register
     ## the Puppet Server Compilers to be internally reachable via DNS.
     ## That is necessary to configure "certname" and "server" in `puppet.conf`.
@@ -138,9 +187,11 @@ puppetserver:
     ##
     fqdns:
       alternateServerNames: ""   # Comma-separated
+
     ## Service for Puppet Server Compilers
     ## The usage of a TCP/Network LB type is strongly preferable
     ## Please check the `README.md` for more information
+    ##
     service:
       type: ClusterIP
       ## The LB type (network protocol) for some cloud providers must be set here.
@@ -166,6 +217,7 @@ puppetserver:
             protocol: TCP
         annotations: {}
         labels: {}
+
     ingress:
       ## If true, Puppet Server Compilers Ingress will be created
       ##
@@ -191,11 +243,14 @@ puppetserver:
       #   - secretName: puppet-compilers-server-tls
       #     hosts:
       #       - puppet-compilers.domain.com
+
   ## Use pre-generated Puppet Master certs in `./init/puppet-certs`
   ## Check README for related use cases
+  ##
   preGeneratedCertsJob:
     enabled: false
     jobDeadline: 300
+
   ## The pattern of managing Hieradata in a separate repository is
   ## both common and acceptable. Doing so provides the ability to decouple
   ## the management of configuration data from that of the Puppet code base.

--- a/values.yaml
+++ b/values.yaml
@@ -152,12 +152,12 @@ puppetserver:
     ## Puppet Server Compiler readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
-    readinessProbeInitialDelay: 120
+    readinessProbeInitialDelay: 180
     readinessProbePeriodSeconds: 30
     readinessProbeTimeout: 30
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
-    livenessProbeInitialDelay: 150
+    livenessProbeInitialDelay: 420
     livenessProbePeriodSeconds: 20
     livenessProbeTimeout: 30
     livenessProbeFailureThreshold: 3

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ puppetserver:
     ##
     readinessProbeInitialDelay: 180
     readinessProbePeriodSeconds: 60
-    readinessProbeTimeout: 10
+    readinessProbeTimeout: 20
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
     livenessProbeInitialDelay: 420
@@ -154,12 +154,12 @@ puppetserver:
     ##
     readinessProbeInitialDelay: 180
     readinessProbePeriodSeconds: 60
-    readinessProbeTimeout: 30
+    readinessProbeTimeout: 20
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
     livenessProbeInitialDelay: 420
     livenessProbePeriodSeconds: 30
-    livenessProbeTimeout: 30
+    livenessProbeTimeout: 10
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1
 

--- a/values.yaml
+++ b/values.yaml
@@ -30,12 +30,14 @@ puppetserver:
     ## Puppet Server Master readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
-    readinessProbeInitialDelay: 60
-    readinessProbeTimeout: 30
+    readinessProbeInitialDelay: 120
+    readinessProbePeriodSeconds: 30
+    readinessProbeTimeout: 10
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
-    livenessProbeInitialDelay: 90
-    livenessProbeTimeout: 30
+    livenessProbeInitialDelay: 150
+    livenessProbePeriodSeconds: 20
+    livenessProbeTimeout: 10
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1
 
@@ -150,11 +152,13 @@ puppetserver:
     ## Puppet Server Compiler readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
-    readinessProbeInitialDelay: 60
+    readinessProbeInitialDelay: 120
+    readinessProbePeriodSeconds: 30
     readinessProbeTimeout: 30
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
-    livenessProbeInitialDelay: 90
+    livenessProbeInitialDelay: 150
+    livenessProbePeriodSeconds: 20
     livenessProbeTimeout: 30
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@
 puppetserver:
   name: puppetserver
   image: puppet/puppetserver
-  tag: 6.10.0
+  tag: 6.12.1
   pullPolicy: IfNotPresent
   ## Mandatory Deployment of Puppet Server Master/s
   ##
@@ -273,7 +273,7 @@ puppetserver:
 r10k:
   name: r10k
   image: puppet/r10k
-  tag: 3.5.1
+  tag: 3.5.2
   pullPolicy: IfNotPresent
   code:
     resources: {}
@@ -341,7 +341,7 @@ r10k:
 postgres:
   name: postgres
   image: postgres
-  tag: 9.6.18
+  tag: 9.6.19
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -358,7 +358,7 @@ postgres:
 puppetdb:
   name: puppetdb
   image: puppet/puppetdb
-  tag: 6.10.1
+  tag: 6.11.3
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -386,7 +386,7 @@ puppetboard:
   enabled: false
   name: puppetboard
   image: xtigyro/puppetboard
-  tag: 2.1.2
+  tag: 2.2.0
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:


### PR DESCRIPTION
- Allow for changing the default Puppet Server ports for Masters and Compilers.
- Switch to percentage `rollingUpdate` strategy for Puppet Masters.
- Set `updateStrategy` to `RollingUpdate` for Puppet Compilers.
- Bump `puppetserver` to `v6.12.1`, `puppetdb` to `v6.11.3`, `r10k` to `v3.5.2`, `puppetboard` to `v2.2.0`, `postgres` to `v9.6.19`.
- Code style fixes in "values.yaml".
- Improve `Testing the Deployed Chart Resources` in `README.md`.

@underscorgan @Iristyle Please use the `Squash and merge` button upon merging.

CC: @slconley @scottcressi @mwaggett @nwolfe @adrienthebo @dhollinger @raphink @binford2k