### PR TITLE
feat(accessModes): make it a configurable parameter for chart PVCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.2.0) (2021-03-29)
+
+- Add ability to change PVC accessModes.
+
 ## [v5.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.1.0) (2021-02-07)
 
 - Add ability to use custom PVCs.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.1.0
+version: 5.2.0
 appVersion: 6.12.1
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `tolerations`| Tolerations for pod assignment |``|
 | `priorityClass`| Leverage a priorityClass to ensure your pods survive resource shortages |``|
 | `podAnnotations`| Extra Pod annotations |``|
+| `storage.accessModes`| Storage Access Modes (expects array) |`- ReadWriteOnce`|
 | `storage.storageClass`| Storage Class |``|
 | `storage.annotations`| Storage annotations |``|
 | `storage.size`| PVCs Storage Size |`400Mi`|

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `tolerations`| Tolerations for pod assignment |``|
 | `priorityClass`| Leverage a priorityClass to ensure your pods survive resource shortages |``|
 | `podAnnotations`| Extra Pod annotations |``|
-| `storage.accessModes`| Storage Access Modes (expects array) |`- ReadWriteOnce`|
+| `storage.accessModes`| Storage Access Modes (expects array) |`["ReadWriteOnce"]`|
 | `storage.storageClass`| Storage Class |``|
 | `storage.annotations`| Storage annotations |``|
 | `storage.size`| PVCs Storage Size |`400Mi`|
@@ -340,3 +340,4 @@ kill %[job_numbers_above]
 * [chwehrli](https://github.com/chwehrli), Contributor
 * [Niels Højen](https://github.com/nielshojen), Contributor
 * [Hryhorii Didenko](https://github.com/HryhoriiDidenko), Contributor
+* [John Stewart](https://github.com/jstewart612), Contributor

--- a/templates/puppetdb-pvc.yaml
+++ b/templates/puppetdb-pvc.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{- toYaml .Values.storage.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}

--- a/templates/puppetserver-code-pvc.yaml
+++ b/templates/puppetserver-code-pvc.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{- toYaml .Values.storage.accessModes | nindent 4 }} 
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}

--- a/templates/puppetserver-data-pvc.yaml
+++ b/templates/puppetserver-data-pvc.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{- toYaml .Values.storage.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}

--- a/templates/puppetserver-pvc.yaml
+++ b/templates/puppetserver-pvc.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{- toYaml .Values.storage.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.storage.size | quote }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -324,7 +324,7 @@ spec:
       {{- end }}
       spec:
         accessModes:
-          - ReadWriteOnce
+          {{- toYaml .Values.storage.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.storage.size }}"
@@ -343,7 +343,7 @@ spec:
       {{- end }}
       spec:
         accessModes:
-          - ReadWriteOnce
+          {{- toYaml .Values.storage.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.storage.size }}"

--- a/values.yaml
+++ b/values.yaml
@@ -575,6 +575,10 @@ podAnnotations: {}
 ## Storage Configuration
 ##
 storage:
+  ## Puppet Server data Persistent Volume Access Modes
+  ## Be sure your chosen Storage Class below allows this Access Mode
+  accessModes:
+    - ReadWriteOnce
   ## Puppet Server data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Fixes [#80 ](https://github.com/puppetlabs/puppetserver-helm-chart/issues/80)

Deliberately did not bump Chart.yaml version to allow you to include other PRs before pushing a chart version bump.

Let me know if there's any other issues with this PR.  Should be relatively straight-forward otherwise.