### PR TITLE
Change the order how env block is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.3.0) (2021-04-22)
+
+- Add ability to ovewrite PuppetBoard variables in order to work properly with newer PuppetDB versions.
+
 ## [v5.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.2.0) (2021-03-29)
 
 - Add ability to change PVC accessModes.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.2.0
+version: 5.3.0
 appVersion: 6.12.1
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -341,3 +341,4 @@ kill %[job_numbers_above]
 * [Niels Højen](https://github.com/nielshojen), Contributor
 * [Hryhorii Didenko](https://github.com/HryhoriiDidenko), Contributor
 * [John Stewart](https://github.com/jstewart612), Contributor
+* [Erlon Pinheiro](https://github.com/erlonpinheiro), Contributor

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -70,10 +70,6 @@ spec:
           resources:
             {{- toYaml .Values.puppetboard.resources | nindent 12 }}
           env:
-            {{- range $key, $value := .Values.puppetboard.extraEnv }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
             - name: PUPPETDB_HOST
               value: "puppetdb"
             - name: PUPPETDB_PORT
@@ -84,6 +80,10 @@ spec:
               value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/public.pem"
             - name: PUPPETDB_KEY
               value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/private.pem"
+            {{- range $key, $value := .Values.puppetboard.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           ports:
             - name: puppetboard
               containerPort: 80


### PR DESCRIPTION
By using a newer puppetDB image, the puppetDB certificate and key path has changed and it is not possible to overwrite the variables responsible to configure that because these variables where defined on the template after the block that reads from value.yaml file.

By changing the order the values will still be coming from template but they will be able to be overwritten by those one added on values.yaml file (since Kubernetes consider the last one).