### PR TITLE
PuppetDB/Puppetboard: fix containers syntax and allow alternate containerPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v5.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.4.0) (2021-04-26)
+## [v5.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.4.0) (2021-04-30)
 
 - fix: use puppetboard.port in puppetboard-ingress.yaml
 - fix: use proper syntax for extra containers in puppetdb-deployment.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.4.0) (2021-04-26)
+
+- fix: use puppetboard.port in puppetboard-ingress.yaml
+- fix: use proper syntax for extra containers in puppetdb-deployment.yaml
+- fix: force targetPorts in puppetdb-service.yaml
+- enhancement: allow to specify puppetboard.service.targetPort
+
 ## [v5.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.4.0) (2021-04-26)
 
 - Use official Puppetboard image, use port 9090, and allow extra PuppetDB containers.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.4.1
+version: 5.5.0
 appVersion: 6.12.1
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.4.0
+version: 5.4.1
 appVersion: 6.12.1
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetdb.extraEnv` | puppetdb additional container env vars |``|
 | `puppetdb.metrics.enabled` | puppetdb metrics enable/disable flag |`false`|
 | `puppetdb.customPersistentVolumeClaim.storage.enable`| If true, use custom PVC for storage |``|
-| `puppetdb.customPersistentVolumeClaim.storage.config `| Configuration for custom PVC for storage |``|
+| `puppetdb.customPersistentVolumeClaim.storage.config`| Configuration for custom PVC for storage |``|
+| `puppetdb.containers`| Extra containers to inject in the puppetdb pod |``|
 | `puppetboard.enabled` | puppetboard availability | `false`|
 | `puppetboard.name` | puppetboard component label | `puppetboard`|
 | `puppetboard.image` | puppetboard img | `xtigyro/puppetboard`|
@@ -251,6 +252,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetboard.pullPolicy` | puppetboard img pull policy | `IfNotPresent`|
 | `puppetboard.resources` | puppetboard resource limits |``|
 | `puppetboard.extraEnv` | puppetboard additional container env vars |``|
+| `puppetboard.service.targetPort` | target port for the puppetboard service port |`puppetboard`|
 | `puppetboard.ingress.enabled`| puppetboard ingress creation enabled |`false`|
 | `puppetboard.ingress.annotations`| puppetboard ingress annotations |``|
 | `puppetboard.ingress.extraLabels`| puppetboard ingress extraLabels |``|

--- a/templates/puppetboard-ingress.yaml
+++ b/templates/puppetboard-ingress.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.puppetboard.ingress.enabled }}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := "puppetdb" }}
-{{- $servicePort := "80" -}}
+{{- $servicePort := .Values.puppetboard.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       hostname: puppetdb
       containers:
-        {{- if .Values.puppetdb.containers }}
-          {{ toYaml .Values.puppetdb.containers | indent 8 }}
+        {{- with .Values.puppetdb.containers }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: puppetdb
           image: "{{.Values.puppetdb.image}}:{{.Values.puppetdb.tag}}"

--- a/templates/puppetdb-service.yaml
+++ b/templates/puppetdb-service.yaml
@@ -8,11 +8,14 @@ spec:
   ports:
     - name: pdb-http
       port: 8080
+      targetPort: pdb-http
     - name: pdb-https
       port: 8081
+      targetPort: pdb-https
     {{- if .Values.puppetboard.enabled }}
     - name: puppetboard
       port: {{ .Values.puppetboard.port }}
+      targetPort: {{ .Values.puppetboard.service.targetPort }}
     {{- end }}
   selector:
     {{- include "puppetserver.puppetdb.matchLabels" . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -437,6 +437,8 @@ puppetboard:
   tag: 3.0.0
   port: 9090
   pullPolicy: IfNotPresent
+  service:
+    targetPort: puppetboard
   resources: {}
   #  requests:
   #    memory: 368Mi


### PR DESCRIPTION
The `indent` syntax actually doesn't work as expected with this chart, so this fixes it.