### PR TITLE
r10k: extra settings + https credentials support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.8.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.8.0) (2021-07-22)
+
+- feat: Add r10k.code.extraSettings and r10k.hiera.extraSettings
+- feat: Add viaHttps options for r10k.code
+
 ## [v5.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.7.0) (2021-07-22)
 
 - update: update to new api version (networking.k8s.io/v1) of ingress (v1.19+)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.7.0
+version: 5.8.0
 appVersion: 7.1.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -278,9 +278,9 @@ Create the name for the PuppetDB password secret.
 {{- end -}}
 
 {{/*
-Create the name for the r10k.code secret.
+Create the name for the r10k.code.viaSsh secret.
 */}}
-{{- define "r10k.code.secret" -}}
+{{- define "r10k.code.viaSsh.secret" -}}
 {{- if .Values.r10k.code.viaSsh.credentials.existingSecret -}}
   {{- .Values.r10k.code.viaSsh.credentials.existingSecret -}}
 {{- else -}}
@@ -289,11 +289,33 @@ Create the name for the r10k.code secret.
 {{- end -}}
 
 {{/*
-Create the name for the r10k.hiera secret.
+Create the name for the r10k.code.viaHttps secret.
 */}}
-{{- define "r10k.hiera.secret" -}}
+{{- define "r10k.code.viaHttps.secret" -}}
+{{- if .Values.r10k.code.viaHttps.credentials.existingSecret -}}
+  {{- .Values.r10k.code.viaHttps.credentials.existingSecret -}}
+{{- else -}}
+  r10k-code-creds
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the r10k.hiera.viaSsh secret.
+*/}}
+{{- define "r10k.hiera.viaSsh.secret" -}}
 {{- if .Values.r10k.hiera.viaSsh.credentials.existingSecret -}}
   {{- .Values.r10k.hiera.viaSsh.credentials.existingSecret -}}
+{{- else -}}
+  r10k-hiera-creds
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the r10k.hiera.viaHttps secret.
+*/}}
+{{- define "r10k.hiera.viaHttps.secret" -}}
+{{- if .Values.r10k.hiera.viaHttps.credentials.existingSecret -}}
+  {{- .Values.r10k.hiera.viaHttps.credentials.existingSecret -}}
 {{- else -}}
   r10k-hiera-creds
 {{- end -}}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -217,8 +217,15 @@ spec:
           volumeMounts:
           {{- with .Values.r10k.code.viaSsh.credentials }}
           {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-          - name: r10k-code-secret
+          - name: r10k-code-ssh
             mountPath: /home/puppet/.ssh
+          {{- end }}
+          {{- end }}
+          {{- with .Values.r10k.code.viaHttps.credentials }}
+          {{- if or .existingSecret .netrc.value }}
+          - name: r10k-code-netrc
+            mountPath: /home/puppet/.netrc
+            subPath: .netrc
           {{- end }}
           {{- end }}
           - name: puppet-code-storage
@@ -253,8 +260,15 @@ spec:
           volumeMounts:
           {{- with .Values.r10k.hiera.viaSsh.credentials }}
           {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-          - name: r10k-hiera-secret
+          - name: r10k-hiera-ssh
             mountPath: /home/puppet/.ssh
+          {{- end }}
+          {{- end }}
+          {{- with .Values.r10k.hiera.viaHttps.credentials }}
+          {{- if or .existingSecret .netrc.value }}
+          - name: r10k-hiera-netrc
+            mountPath: /home/puppet/.netrc
+            subPath: .netrc
           {{- end }}
           {{- end }}
           - name: puppet-code-storage
@@ -330,10 +344,24 @@ spec:
             name: {{ template "puppetserver.hiera.privateMap" . }}
         {{- end }}
         {{- if or (.Values.r10k.code.viaSsh.credentials.existingSecret) (and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value)) }}
-        - name: r10k-code-secret
+        - name: r10k-code-ssh
           secret:
-            secretName: {{ template "r10k.code.secret" . }}
+            secretName: {{ template "r10k.code.viaSsh.secret" . }}
             defaultMode: 288 # = mode 0440
+            items:
+              - key: id_rsa
+                path: id_rsa
+              - key: known_hosts
+                path: known_hosts
+        {{- end }}
+        {{- if or .Values.r10k.code.viaHttps.credentials.existingSecret .Values.r10k.code.viaHttps.credentials.netrc.value }}
+        - name: r10k-code-netrc
+          secret:
+            secretName: {{ template "r10k.code.viaHttps.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: netrc
+                path: .netrc
         {{- end }}
         {{- if .Values.puppetserver.puppeturl }}
         - name: r10k-code-volume
@@ -346,10 +374,24 @@ spec:
             name: r10k-hiera-config
         {{- end }}
         {{- if or (.Values.r10k.hiera.viaSsh.credentials.existingSecret) (and (.Values.r10k.hiera.viaSsh.credentials.ssh.value) (.Values.r10k.hiera.viaSsh.credentials.known_hosts.value)) }}
-        - name: r10k-hiera-secret
+        - name: r10k-hiera-ssh
           secret:
-            secretName: {{ template "r10k.hiera.secret" . }}
+            secretName: {{ template "r10k.hiera.viaSsh.secret" . }}
             defaultMode: 288 # = mode 0440
+            items:
+              - key: id_rsa
+                path: id_rsa
+              - key: known_hosts
+                path: known_hosts
+        {{- end }}
+        {{- if or .Values.r10k.hiera.viaHttps.credentials.existingSecret .Values.r10k.hiera.viaHttps.credentials.netrc.value }}
+        - name: r10k-hiera-netrc
+          secret:
+            secretName: {{ template "r10k.hiera.viaHttps.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: netrc
+                path: .netrc
         {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -202,8 +202,15 @@ spec:
           volumeMounts:
           {{- with .Values.r10k.code.viaSsh.credentials }}
           {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-          - name: r10k-code-secret
+          - name: r10k-code-ssh
             mountPath: /home/puppet/.ssh
+          {{- end }}
+          {{- end }}
+          {{- with .Values.r10k.code.viaHttps.credentials }}
+          {{- if or .existingSecret .netrc.value }}
+          - name: r10k-code-netrc
+            mountPath: /home/puppet/.netrc
+            subPath: .netrc
           {{- end }}
           {{- end }}
           - name: puppet-code-volume
@@ -238,8 +245,15 @@ spec:
           volumeMounts:
           {{- with .Values.r10k.hiera.viaSsh.credentials }}
           {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-          - name: r10k-hiera-secret
+          - name: r10k-hiera-ssh
             mountPath: /home/puppet/.ssh
+          {{- end }}
+          {{- end }}
+          {{- with .Values.r10k.hiera.viaHttps.credentials }}
+          {{- if or .existingSecret .netrc.value }}
+          - name: r10k-hiera-netrc
+            mountPath: /home/puppet/.netrc
+            subPath: .netrc
           {{- end }}
           {{- end }}
           - name: puppet-code-volume
@@ -282,10 +296,24 @@ spec:
             name: {{ template "puppetserver.hiera.privateMap" . }}
         {{- end }}
         {{- if or (.Values.r10k.code.viaSsh.credentials.existingSecret) (and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value)) }}
-        - name: r10k-code-secret
+        - name: r10k-code-ssh
           secret:
-            secretName: {{ template "r10k.code.secret" . }}
+            secretName: {{ template "r10k.code.viaSsh.secret" . }}
             defaultMode: 288 # = mode 0440
+            items:
+              - key: id_rsa
+                path: id_rsa
+              - key: known_hosts
+                path: known_hosts
+        {{- end }}
+        {{- if or .Values.r10k.code.viaHttps.credentials.existingSecret .Values.r10k.code.viaHttps.credentials.netrc.value }}
+        - name: r10k-code-netrc
+          secret:
+            secretName: {{ template "r10k.code.viaHttps.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: netrc
+                path: .netrc
         {{- end }}
         {{- if .Values.puppetserver.puppeturl }}
         - name: r10k-code-volume
@@ -298,10 +326,24 @@ spec:
             name: r10k-hiera-config
         {{- end }}
         {{- if or (.Values.r10k.hiera.viaSsh.credentials.existingSecret) (and (.Values.r10k.hiera.viaSsh.credentials.ssh.value) (.Values.r10k.hiera.viaSsh.credentials.known_hosts.value)) }}
-        - name: r10k-hiera-secret
+        - name: r10k-hiera-ssh
           secret:
-            secretName: {{ template "r10k.hiera.secret" . }}
+            secretName: {{ template "r10k.hiera.viaSsh.secret" . }}
             defaultMode: 288 # = mode 0440
+            items:
+              - key: id_rsa
+                path: id_rsa
+              - key: known_hosts
+                path: known_hosts
+        {{- end }}
+        {{- if or .Values.r10k.hiera.viaHttps.credentials.existingSecret .Values.r10k.hiera.viaHttps.credentials.netrc.value }}
+        - name: r10k-hiera-netrc
+          secret:
+            secretName: {{ template "r10k.hiera.viaHttps.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: netrc
+                path: .netrc
         {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/templates/r10k-code-secret.yaml
+++ b/templates/r10k-code-secret.yaml
@@ -1,9 +1,9 @@
-{{- if and (.Values.puppetserver.puppeturl) (not .Values.r10k.code.viaSsh.credentials.existingSecret) }}
-{{- if and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value) }}
+{{- if and (.Values.puppetserver.puppeturl) (or (not .Values.r10k.code.viaSsh.credentials.existingSecret) (not .Values.r10k.code.viaHttps.credentials.existingSecret)) }}
+{{- if or (and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value)) (.Values.r10k.code.viaHttps.credentials) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "r10k.code.secret" . }}
+  name: r10k-code-creds
   labels:
     {{- include "puppetserver.r10k.labels" . | nindent 4 }}
 type: Opaque
@@ -12,6 +12,11 @@ data:
   {{- if and (.ssh.value) (.known_hosts.value) }}
   id_rsa: {{ .ssh.value | b64enc | quote }}
   known_hosts: {{ .known_hosts.value | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.r10k.code.viaHttps.credentials }}
+  {{- if .netrc.value }}
+  netrc: {{ .netrc.value | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -16,6 +16,7 @@ data:
       :puppet_repo:
         remote: '{{.Values.puppetserver.puppeturl}}'
         basedir: '/etc/puppetlabs/code/environments'
+    {{ .Values.r10k.code.extraSettings | nindent 4 }}
 
   r10k_code_cronjob.sh: |
     #!/usr/bin/env sh

--- a/templates/r10k-hiera-secret.yaml
+++ b/templates/r10k-hiera-secret.yaml
@@ -1,9 +1,9 @@
-{{- if and (.Values.hiera.hieradataurl) (not .Values.r10k.hiera.viaSsh.credentials.existingSecret) }}
-{{- if and (.Values.r10k.hiera.viaSsh.credentials.ssh.value) (.Values.r10k.hiera.viaSsh.credentials.known_hosts.value) }}
+{{- if and (.Values.hiera.hieradataurl) (or (not .Values.r10k.hiera.viaSsh.credentials.existingSecret) (not .Values.r10k.hiera.viaHttps.credentials.existingSecret)) }}
+{{- if or (and (.Values.r10k.hiera.viaSsh.credentials.ssh.value) (.Values.r10k.hiera.viaSsh.credentials.known_hosts.value)) (.Values.r10k.hiera.viaHttps.credentials) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "r10k.hiera.secret" . }}
+  name: r10k-hiera-creds
   labels:
     {{- include "puppetserver.r10k.labels" . | nindent 4 }}
 type: Opaque
@@ -12,6 +12,11 @@ data:
   {{- if and (.ssh.value) (.known_hosts.value) }}
   id_rsa: {{ .ssh.value | b64enc | quote }}
   known_hosts: {{ .known_hosts.value | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.r10k.hiera.viaHttps.credentials }}
+  {{- if .netrc.value }}
+  netrc: {{ .netrc.value | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -16,6 +16,7 @@ data:
       :hiera_repo:
         remote: '{{.Values.hiera.hieradataurl}}'
         basedir: '/etc/puppetlabs/code/hiera-data'
+    {{ .Values.r10k.hiera.extraSettings | nindent 4 }}
 
   r10k_hiera_cronjob.sh: |
     #!/usr/bin/env sh

--- a/values.yaml
+++ b/values.yaml
@@ -305,6 +305,7 @@ r10k:
     #   - --color
     ## Additional r10k code container environment variables
     extraEnv: {}
+    extraSettings: ""
     viaHttps:
       credentials:
         netrc:
@@ -346,6 +347,7 @@ r10k:
     #   - --color
     ## Additional puppetserver hiera container environment variables
     extraEnv: {}
+    extraSettings: ""
     viaHttps:
       credentials:
         netrc:

--- a/values.yaml
+++ b/values.yaml
@@ -305,7 +305,16 @@ r10k:
     #   - --color
     ## Additional r10k code container environment variables
     extraEnv: {}
-    extraSettings: ""
+    viaHttps:
+      credentials:
+        netrc:
+          ## A multi-line string
+          value:  # |
+            #  NETRC CONTENTS
+        ## or set the r10k netrc file
+        ## from a pre-existing K8s secret
+        ## NOTE: Using this secret supercedes all other credentials settings.
+        existingSecret: ""
     viaSsh:
       credentials:
         ssh:
@@ -337,7 +346,16 @@ r10k:
     #   - --color
     ## Additional puppetserver hiera container environment variables
     extraEnv: {}
-    extraSettings: ""
+    viaHttps:
+      credentials:
+        netrc:
+          ## A multi-line string
+          value:  # |
+            #  NETRC CONTENTS
+        ## or set the r10k netrc file
+        ## from a pre-existing K8s secret
+        ## NOTE: Using this secret supercedes all other credentials settings.
+        existingSecret: ""
     viaSsh:
       credentials:
         ssh:

--- a/values.yaml
+++ b/values.yaml
@@ -305,6 +305,7 @@ r10k:
     #   - --color
     ## Additional r10k code container environment variables
     extraEnv: {}
+    extraSettings: ""
     viaSsh:
       credentials:
         ssh:
@@ -336,6 +337,7 @@ r10k:
     #   - --color
     ## Additional puppetserver hiera container environment variables
     extraEnv: {}
+    extraSettings: ""
     viaSsh:
       credentials:
         ssh:


### PR DESCRIPTION
- feat: Add r10k.code.extraSettings and r10k.hiera.extraSettings
- feat: Add viaHttps options for r10k.code
- Release 5.8.0


This PR adds various options for r10k settings:
- extra settings in r10k.yaml (e.g. for a forge proxy)
- `viaHttps` settings to set a `.netrc` file, when SSH is not an option