### PR TITLE
update to new api version of ingress (v1.19+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v5.6.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.6.3) (2021-07-22)
+## [v5.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.7.0) (2021-07-22)
 
 - update: update to new api version (networking.k8s.io/v1) of ingress (v1.19+)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.6.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.6.3) (2021-07-22)
+
+- update: update to new api version (networking.k8s.io/v1) of ingress (v1.19+)
+
 ## [v5.6.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.6.2) (2021-07-21)
 
 - fix: add pathType Prefix to puppetboard ingress

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.6.3
+version: 5.7.0
 appVersion: 7.1.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.6.2
+version: 5.6.3
 appVersion: 7.1.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetboard-ingress.yaml
+++ b/templates/puppetboard-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := "puppetdb" }}
 {{- $servicePort := .Values.puppetboard.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   {{- if .Values.puppetboard.ingress.annotations }}
@@ -26,8 +26,10 @@ spec:
           - path: /{{ rest $url | join "/" }}
             pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.puppetboard.ingress.tls }}
   tls:

--- a/templates/puppetserver-ingress-compilers.yaml
+++ b/templates/puppetserver-ingress-compilers.yaml
@@ -3,7 +3,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "puppetserver.puppetserver-compilers.serviceName" . }}
 {{- $servicePort := .Values.puppetserver.compilers.service.ports.puppetserver.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   {{- if .Values.puppetserver.compilers.ingress.annotations }}
@@ -25,8 +25,10 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.puppetserver.compilers.ingress.tls }}
   tls:

--- a/templates/puppetserver-ingress-masters.yaml
+++ b/templates/puppetserver-ingress-masters.yaml
@@ -2,7 +2,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "puppetserver.puppetserver-masters.serviceName" . }}
 {{- $servicePort := .Values.puppetserver.masters.service.ports.puppetserver.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   {{- if .Values.puppetserver.masters.ingress.annotations }}
@@ -24,8 +24,10 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.puppetserver.masters.ingress.tls }}
   tls:


### PR DESCRIPTION
The current API version of ingress in use will be deprecated in version v1.22.
See the API deprecation guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122