### PR TITLE
allow to override PUPPETDB_POSTGRES_HOSTNAME for puppetdb container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.9.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.9.0) (2021-08-12)
+
+- feat: allow to override PUPPETDB_POSTGRES_HOSTNAME for puppetdb container
+
 ## [v5.8.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.8.0) (2021-07-22)
 
 - feat: Add r10k.code.extraSettings and r10k.hiera.extraSettings

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.8.0
+version: 5.9.0
 appVersion: 7.1.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -38,8 +38,10 @@ spec:
               value: "puppet"
             - name: PUPPETSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
+            {{- if not (hasKey .Values.puppetdb.extraEnv "PUPPETDB_POSTGRES_HOSTNAME") }}
             - name: PUPPETDB_POSTGRES_HOSTNAME
               value: "{{ template "puppetserver.name" . }}-postgresql"
+            {{- end }}
             - name: PUPPETDB_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
this allows for connecting to a separate/remote postgres server