### PR TITLE
allow to expose puppetdb service outside of the kubernetes cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.10.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.10.0) (2021-08-30)
+
+- feat: allow to expose puppetdb service outside of the kubernetes cluster
+
 ## [v5.9.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.9.0) (2021-08-12)
 
 - feat: allow to override PUPPETDB_POSTGRES_HOSTNAME for puppetdb container

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.9.0
+version: 5.10.0
 appVersion: 7.1.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetdb-service.yaml
+++ b/templates/puppetdb-service.yaml
@@ -4,6 +4,13 @@ metadata:
   name: puppetdb
   labels:
     {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
+    {{- if .Values.puppetdb.service.labels }}
+    {{- toYaml .Values.puppetdb.service.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.puppetdb.service.annotations }}
+  annotations:
+    {{- toYaml .Values.puppetdb.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: pdb-http
@@ -19,3 +26,7 @@ spec:
     {{- end }}
   selector:
     {{- include "puppetserver.puppetdb.matchLabels" . | nindent 4 }}
+  type: {{ .Values.puppetdb.service.type }}
+  {{- if (and (eq .Values.puppetdb.service.type "LoadBalancer") (not (empty .Values.puppetdb.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.puppetdb.service.loadBalancerIP }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -391,6 +391,21 @@ puppetdb:
   extraContainers: []
   ## Additional puppetdb container environment variables
   extraEnv: {}
+
+  ## Service for PuppetDB
+  service:
+    ## The LB type (network protocol) for some cloud providers must be set here.
+    type: ClusterIP
+    ## Exemplary annotations for few cloud providers
+    annotations: {}
+    #  service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    #  service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    #  service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    #  cloud.google.com/load-balancer-type: "Internal"
+    #  service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
+    labels: {}
+    loadBalancerIP: ""
+
   ## puppetdb metrics enable/disable flag
   metrics:
     enabled: false


### PR DESCRIPTION
this allows me to query puppetdb and access puppetboard from outside of the kubernetes cluster