### PR TITLE
set securityContext for puppetboard container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.11.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.11.0) (2021-08-30)
+
+- fix: set securityContext for puppetboard container
+
 ## [v5.10.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.10.0) (2021-08-30)
 
 - feat: allow to expose puppetdb service outside of the kubernetes cluster

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.10.0
+version: 5.11.0
 appVersion: 7.1.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -346,3 +346,4 @@ kill %[job_numbers_above]
 * [Hryhorii Didenko](https://github.com/HryhoriiDidenko), Contributor
 * [John Stewart](https://github.com/jstewart612), Contributor
 * [Erlon Pinheiro](https://github.com/erlonpinheiro), Contributor
+* [Reinier Schoof](https://github.com/skoef), Contributor

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -94,6 +94,10 @@ spec:
           ports:
             - name: puppetboard
               containerPort: {{ .Values.puppetboard.port }}
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            privileged: true
           volumeMounts:
             - name: puppetdb-storage
               mountPath: /opt/puppetlabs/server/data/puppetdb/certs


### PR DESCRIPTION
The [voxpupuli puppetboard container](https://github.com/voxpupuli/puppetboard/blob/master/Dockerfile) runs as root so this should be reflected in the deployment to satisfy security policies.