### PR TITLE
Allow configuration of update strategy for deployments and statefulsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.16.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.16.0) (2022-04-05)
+
+- feat: make update strategy configurable
+
 ## [v5.15.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.15.0) (2022-04-20)
 
 - feat: use k8s secrets instead of configmaps for eyaml secrets

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.15.0
+version: 5.16.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
 | `puppetserver.masters.resources` | puppetserver masters resource limits | ``|
 | `puppetserver.masters.extraEnv` | puppetserver masters additional container env vars |``|
+| `puppetserver.masters.updateStrategy` | puppetserver masters update strategy |`RollingUpdate`|
 | `puppetserver.masters.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
 | `puppetserver.masters.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `60`|
 | `puppetserver.masters.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `20`|
@@ -170,6 +171,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.compilers.podAntiAffinity` | puppetserver compilers pod affinity constraints |`false`|
 | `puppetserver.compilers.annotations`| puppetserver compilers statefulset annotations |``|
 | `puppetserver.compilers.extraEnv` | puppetserver compilers additional container env vars |``|
+| `puppetserver.compilers.updateStrategy` | puppetserver compilers update strategy |`RollingUpdate`|
 | `puppetserver.compilers.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
 | `puppetserver.compilers.readinessProbePeriodSeconds` | how often (in seconds) to perform the puppetserver masters readiness probe | `60`|
 | `puppetserver.compilers.readinessProbeTimeout` | the timeout for the puppetserver masters readiness probe | `20`|
@@ -240,6 +242,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`|
 | `puppetdb.resources` | puppetdb resource limits |``|
 | `puppetdb.extraEnv` | puppetdb additional container env vars |``|
+| `puppetdb.updateStrategy` | puppetdb update strategy |`Recreate`|
 | `puppetdb.metrics.enabled` | puppetdb metrics enable/disable flag |`false`|
 | `puppetdb.customPersistentVolumeClaim.storage.enable`| If true, use custom PVC for storage |``|
 | `puppetdb.customPersistentVolumeClaim.storage.config`| Configuration for custom PVC for storage |``|
@@ -348,3 +351,4 @@ kill %[job_numbers_above]
 * [Erlon Pinheiro](https://github.com/erlonpinheiro), Contributor
 * [Reinier Schoof](https://github.com/skoef), Contributor
 * [Manasseh MMadu](https://github.com/mensaah), Contributor
+* [Aidan](https://github.com/artificial-aidan), Contributor

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -8,8 +8,9 @@ spec:
   selector:
     matchLabels:
       {{- include "puppetserver.puppetdb.matchLabels" . | nindent 6 }}
-  strategy:
-    type: Recreate
+  {{- if .Values.puppetdb.updateStrategy }}
+  strategy: {{- toYaml .Values.puppetdb.updateStrategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -13,11 +13,9 @@ spec:
   selector:
     matchLabels:
       {{- include "puppetserver.puppetserver.matchLabels" . | nindent 6 }}
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 20%
-      maxUnavailable: 0%
+  {{- if .Values.puppetserver.masters.updateStrategy }}
+  strategy: {{- toYaml .Values.puppetserver.masters.updateStrategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -18,8 +18,9 @@ spec:
   replicas: {{ .Values.puppetserver.compilers.manualScaling.compilers }}
   {{- end }}
   podManagementPolicy: {{ .Values.puppetserver.compilers.podManagementPolicy }}
-  updateStrategy:
-    type: RollingUpdate
+  {{- if .Values.puppetserver.compilers.updateStrategy }}
+  updateStrategy: {{- toYaml .Values.puppetserver.compilers.updateStrategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,12 @@ puppetserver:
     ##
     extraEnv: {}
 
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 20%
+        maxUnavailable: 0%
+
     ## Puppet Server Master readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
@@ -167,6 +173,9 @@ puppetserver:
     ## Additional Compilers' container environment variables
     ##
     extraEnv: {}
+
+    updateStrategy:
+      type: RollingUpdate
 
     ## Puppet Server Compiler readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -391,6 +400,9 @@ puppetdb:
   extraContainers: []
   ## Additional puppetdb container environment variables
   extraEnv: {}
+
+  updateStrategy:
+    type: Recreate
 
   ## Service for PuppetDB
   service:


### PR DESCRIPTION
I left the defaults the same, just made them configurable.

Let me know what I should do for versioning and changelog