### PR TITLE
Fix eyaml secret configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v5.18.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.18.1) (2022-05-27)
+## [v5.19.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.19.0) (2022-05-27)
 
 - feat: deploy only necessary configuration regarding the solution (secret, keys defined in values.yaml, configmap )
 - feat deploy only the most secure configuration (secret > keys defined in values.yaml > configMap)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.18.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.18.1) (2022-05-27)
+
+- feat: deploy only necessary configuration regarding the solution (secret, keys defined in values.yaml, configmap )
+- feat deploy only the most secure configuration (secret > keys defined in values.yaml > configMap)
+- feat: generate a warning if configmap or keys are defined in values.yaml is used
+- feat: generate an error if keys are defined in values.yaml and if .Values.eyaml.public_key or .Values.eyaml.private_key is missing
+
 ## [v5.18.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.18.0) (2022-05-20)
 
 - feat: add pod security policies

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.18.1
+version: 5.19.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.18.0
+version: 5.18.1
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -21,5 +21,12 @@ Control Repo: "{{.Values.puppetserver.puppeturl}}"
 Hieradata Repo: "{{.Values.hiera.hieradataurl}}"
 {{- end }}
 
+{{ if .Values.hiera.eyaml.existingMap -}}
+WARNING: you specified a ConfigMap for eyaml secret and it unsecure 
+{{- end }}
+{{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) }}
+WARNING: you specified a eyaml keys inside the values.yaml and it unsecure 
+{{- end }}
+
 If you need to get your password for PuppetDB and PostgreSQL:
 $ printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "puppetdb.secret" . }} -o jsonpath="{.data.password}" | base64 --decode);echo

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -348,6 +348,42 @@ Create the name for the r10k.hiera.viaHttps secret.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the name for the hiera eyaml private key Secrets.
+*/}}
+{{- define "puppetserver.hiera.privateSecret" -}}
+  eyamlpriv-secret
+{{- end -}}
+
+{{/*
+Create the name for the hiera eyaml public cert Secrets.
+*/}}
+{{- define "puppetserver.hiera.publicSecret" -}}
+  eyamlpub-secret
+{{- end -}}
+
+{{/*
+Test if eyaml is enable or not
+*/}}
+{{- define "puppetserver.hiera.eyaml.enabled" -}}
+{{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingSecret) (.Values.hiera.eyaml.existingMap) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if eyaml keys are stored in secret
+*/}}
+{{- define "puppetserver.hiera.eyaml.secret.enabled" -}}
+{{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingSecret) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{/* *************************************************************************************
 The following definitions were more complex and necessary during part of this development.
 Now they are essentially just stubs but left here in case they might be needed again soon.
@@ -371,16 +407,4 @@ Create the name for the hiera eyaml key secret (private/public keys combined).
 {{- end -}}
 {{- end -}}
 
-{{/*
-Create the name for the hiera eyaml private key Secrets.
-*/}}
-{{- define "puppetserver.hiera.privateSecret" -}}
-  eyamlpriv-secret
-{{- end -}}
 
-{{/*
-Create the name for the hiera eyaml public cert Secrets.
-*/}}
-{{- define "puppetserver.hiera.publicSecret" -}}
-  eyamlpub-secret
-{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -362,28 +362,6 @@ Create the name for the hiera eyaml public cert Secrets.
   eyamlpub-secret
 {{- end -}}
 
-{{/*
-Test if eyaml is enable or not
-*/}}
-{{- define "puppetserver.hiera.eyaml.enabled" -}}
-{{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingSecret) (.Values.hiera.eyaml.existingMap) -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end -}}
-
-{{/*
-Check if eyaml keys are stored in secret
-*/}}
-{{- define "puppetserver.hiera.eyaml.secret.enabled" -}}
-{{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingSecret) -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end -}}
-
 {{/* *************************************************************************************
 The following definitions were more complex and necessary during part of this development.
 Now they are essentially just stubs but left here in case they might be needed again soon.
@@ -406,5 +384,3 @@ Create the name for the hiera eyaml key secret (private/public keys combined).
   {{- .Values.hiera.eyaml.existingSecret -}}
 {{- end -}}
 {{- end -}}
-
-

--- a/templates/private_key.pkcs7.pem.yaml
+++ b/templates/private_key.pkcs7.pem.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hiera.eyaml.private_key) (not .Values.r10k.hiera.viaSsh.credentials.existingSecret) }}
+{{- if and (.Values.hiera.eyaml.public_key) (not .Values.r10k.hiera.viaSsh.credentials.existingSecret) (not .Values.hiera.eyaml.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,7 @@ metadata:
   labels:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
-  private_key.pkcs7.pem: {{ .Values.hiera.eyaml.private_key | nindent 4 | b64enc }}
+  private_key.pkcs7.pem: {{ required "A valid .Values.hiera.eyaml.private_key required!" .Values.hiera.eyaml.private_key | nindent 4 | b64enc }}
 {{- end }}
+
+

--- a/templates/public_key.pkcs7.pem.yaml
+++ b/templates/public_key.pkcs7.pem.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.hiera.eyaml.public_key) (not .Values.r10k.hiera.viaSsh.credentials.existingSecret) }}
+{{- if and (.Values.hiera.eyaml.private_key) (not .Values.r10k.hiera.viaSsh.credentials.existingSecret) (not .Values.hiera.eyaml.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,7 @@ metadata:
   labels:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
-  public_key.pkcs7.pem: {{ .Values.hiera.eyaml.public_key | nindent 4 | b64enc }}
+  public_key.pkcs7.pem: {{ required "A valid .Values.hiera.eyaml.public_key required!" .Values.hiera.eyaml.public_key | nindent 4 | b64enc }}
 {{- end }}
+
+

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -81,7 +81,7 @@ spec:
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
-              {{- if and (include "puppetserver.hiera.eyaml.enabled" .) (not .Values.hiera.eyaml.existingSecret) }}
+              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) -}}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
@@ -131,7 +131,7 @@ spec:
             - name: manifests-volume
               mountPath: /etc/puppetlabs/puppet/configmap/site.pp
               subPath: site.pp
-            {{- if and (.Values.hiera.eyaml.existingMap) (not (include "puppetserver.hiera.eyaml.secret.enabled" .)) }}
+            {{- if and (.Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingSecret) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
             {{- end }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -81,11 +81,9 @@ spec:
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
-              {{- if or (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) }}
+              {{- if and (include "puppetserver.hiera.eyaml.enabled" .) (not .Values.hiera.eyaml.existingSecret) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
-              {{- end }}
-              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.existingMap) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
               {{- end }}
@@ -133,16 +131,14 @@ spec:
             - name: manifests-volume
               mountPath: /etc/puppetlabs/puppet/configmap/site.pp
               subPath: site.pp
-            {{- if .Values.hiera.eyaml.existingMap }}
+            {{- if and (.Values.hiera.eyaml.existingMap) (not (include "puppetserver.hiera.eyaml.secret.enabled" .)) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
             {{- end }}
-            {{- if and (.Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.existingMap)}}
+            {{- if and (or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key)) (not .Values.hiera.eyaml.existingSecret)}}
             - name: eyamlpub-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/public_key.pkcs7.pem
               subPath: public_key.pkcs7.pem
-            {{- end }}
-            {{- if and (.Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingMap)}}
             - name: eyamlpriv-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
@@ -333,20 +329,17 @@ spec:
         - name: eyaml-volume
           secret:
             secretName: {{ .Values.hiera.eyaml.existingSecret }}
-        {{- else if .Values.hiera.eyaml.existingMap }}
-        - name: eyaml-volume
-          configMap:
-            name: {{ .Values.hiera.eyaml.existingMap }}
-        {{- end }}
-        {{- if and (.Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.existingSecret)}}
+        {{- else if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) }}
         - name: eyamlpub-volume
           secret:
             secretName: {{ template "puppetserver.hiera.publicSecret" . }}
-        {{- end }}
-        {{- if and (.Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.existingSecret)}}
         - name: eyamlpriv-volume
           secret:
             secretName: {{ template "puppetserver.hiera.privateSecret" . }}
+        {{- else if .Values.hiera.eyaml.existingMap  }}
+        - name: eyaml-volume
+          configMap:
+            name: {{ .Values.hiera.eyaml.existingMap }}
         {{- end }}
         {{- if or (.Values.r10k.code.viaSsh.credentials.existingSecret) (and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value)) }}
         - name: r10k-code-ssh

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -67,16 +67,14 @@ spec:
               chmod +x /etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh /etc/puppetlabs/puppet/r10k_hiera_cronjob.sh;
               {{- end }}
               {{- if .Values.hiera.config }}
-              cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
+              cp /etc/puppetlabs/puppet/configmap/hiera.ya(not .Values.hiera.eyaml.existingSecret)ml /etc/puppetlabs/puppet/hiera.yaml;
               chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
-              {{- if or (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) }}
+              {{- if and (include "puppetserver.hiera.eyaml.enabled" .) (not .Values.hiera.eyaml.existingSecret) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
-              {{- end }}
-              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.existingMap) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
               {{- end }}
@@ -119,16 +117,14 @@ spec:
             - name: manifests-volume
               mountPath: /etc/puppetlabs/puppet/configmap/site.pp
               subPath: site.pp
-            {{- if .Values.hiera.eyaml.existingMap }}
+            {{- if and (.Values.hiera.eyaml.existingMap) (not (include "puppetserver.hiera.eyaml.secret.enabled" .)) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
             {{- end }}
-            {{- if and (.Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.existingMap)}}
+            {{- if and (or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key)) (not .Values.hiera.eyaml.existingSecret)}}
             - name: eyamlpub-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/public_key.pkcs7.pem
               subPath: public_key.pkcs7.pem
-            {{- end }}
-            {{- if and (.Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingMap)}}
             - name: eyamlpriv-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
@@ -288,20 +284,17 @@ spec:
         - name: eyaml-volume
           secret:
             secretName: {{ .Values.hiera.eyaml.existingSecret }}
+        {{- else if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) }}
+        - name: eyamlpub-volume
+          secret:
+            secretName: {{ template "puppetserver.hiera.publicSecret" . }}
+        - name: eyamlpriv-volume
+          secret:
+            secretName: {{ template "puppetserver.hiera.privateSecret" . }}
         {{- else if .Values.hiera.eyaml.existingMap }}
         - name: eyaml-volume
           configMap:
             name: {{ .Values.hiera.eyaml.existingMap }}
-        {{- end }}
-        {{- if and (.Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.existingSecret)}}
-        - name: eyamlpub-volume
-          secret:
-            secretName: {{ template "puppetserver.hiera.publicSecret" . }}
-        {{- end }}
-        {{- if and (.Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.existingSecret)}}
-        - name: eyamlpriv-volume
-          secret:
-            secretName: {{ template "puppetserver.hiera.privateSecret" . }}
         {{- end }}
         {{- if or (.Values.r10k.code.viaSsh.credentials.existingSecret) (and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value)) }}
         - name: r10k-code-ssh

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -67,12 +67,12 @@ spec:
               chmod +x /etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh /etc/puppetlabs/puppet/r10k_hiera_cronjob.sh;
               {{- end }}
               {{- if .Values.hiera.config }}
-              cp /etc/puppetlabs/puppet/configmap/hiera.ya(not .Values.hiera.eyaml.existingSecret)ml /etc/puppetlabs/puppet/hiera.yaml;
+              cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
               chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
-              {{- if and (include "puppetserver.hiera.eyaml.enabled" .) (not .Values.hiera.eyaml.existingSecret) }}
+              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) -}}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
@@ -117,7 +117,7 @@ spec:
             - name: manifests-volume
               mountPath: /etc/puppetlabs/puppet/configmap/site.pp
               subPath: site.pp
-            {{- if and (.Values.hiera.eyaml.existingMap) (not (include "puppetserver.hiera.eyaml.secret.enabled" .)) }}
+            {{- if and (.Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingSecret) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
             {{- end }}


### PR DESCRIPTION
- feat: deploy only necessary configuration regarding the solution (secret, keys stored in values.yaml, configmap )
- feat deploy only the most secure configuration (secret > keys stored in values.yaml > configMap)
- feat: generate a warning if configmap or keys stored in values.yaml is use
- feat: generate an error if keys stored in values.yaml is use and if `.Values.eyaml.public_key` or `.Values.eyaml.private_key` is missing