### PR TITLE
Add Single CA feature + fix minor issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v5.21.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.21.0) (2022-06-01)
+
+- feat: Single CA support (https://puppet.com/docs/puppet/7/config_ssl_external_ca.html)
+- fix: define podsecuritypolicy.apiVersion
+- fix copy issue with eyaml keys when use `existingSecret`
+- fix puppetdb volume issue when use `customPersistentVolumeClaim`
+- refactoring serviceAccount name
+
 ## [v5.20.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.20.0) (2022-05-31)
 
 - Allow r10k cron jobs to be disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v5.21.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.21.0) (2022-06-01)
+## [v6.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.0.0) (2022-06-01)
 
 - feat: Single CA support (https://puppet.com/docs/puppet/7/config_ssl_external_ca.html)
 - fix: define podsecuritypolicy.apiVersion

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: puppetserver
-version: 5.20.0
+version: 6.0.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `storage.storageClass`| Storage Class |``|
 | `storage.annotations`| Storage annotations |``|
 | `storage.size`| PVCs Storage Size |`400Mi`|
+| `singleCA.enabled`| Enable single CA |`false`|
+| `singleCA.cronJob.schedule`| crl cron job schedule policy |`* 0 * * * *`|
+| `singleCA.extraEnv`| crl additional container env vars |``|
+| `singleCA.resources`| crl container resource limits |``|
+| `singleCA.config`| override the default crl script to retrieve the crl.pem |`see values.yaml`|
+| `singleCA.crl.url`| set the url where crl.pem is located (MANDATORY) |``|
+| `singleCA.crl.credential.existingSecret`| set credential of `crl.url` if needed |``|
+| `singleCA.puppetdb.overrideHostname`| override the puppetdb hostname, needed when using CA where you can't add private SAN name |``|
+| `singleCA.certificates.existingSecret.puppetserver`| existing k8s secret that holds `ca.pem`, `puppet.pem` & `puppet.key` |``|
+| `singleCA.certificates.existingSecret.puppetdb`| existing k8s secret that holds `ca.pem`, `puppetdb.pem` & `puppetdb.key` |``|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ If you prefer not to auto-sign or manually sign the Puppet Agents' CSRs - you ca
 
 > **NOTE**: For more information please check - [README.md](init/README.md). For more general knowledge on the matter you can also read the article - <https://puppet.com/docs/puppet/5.5/ssl_regenerate_certificates.html.>
 
+## Using Single CA
+
+If you prefer, you can use a single externally issued CA - <https://puppet.com/docs/puppet/7/config_ssl_external_ca.html>.  
+Enable it with `.Values.singleCA.enable`, add the crl.pem url with `.Values.singleCA.crl.url`, optionnally you can pass credential using `.Values.singleCA.crl.credential.existingSecret`. 
+
+Generate puppet & puppetdb secret (must be name `puppet.pem` & `puppetdb.pem`):
+```
+kubectl create secret generic puppet-certificate --from-file=puppet.pem --from-file=puppet.key --from-file=ca.pem
+kubectl create secret generic puppetdb-certificate --from-file=puppetdb.pem --from-file=puppetdb.key --from-file=ca.pem
+```
+finally set `.Values.singleCA.certificates.existingSecret.puppetserver` and `.Values.singleCA.certificates.existingSecret.puppetdb`.
+
+Additionnaly, if you use a public certificate authority, you can't use private SAN name, so you have to override puppetdb name with `.Values.singleCA.puppetdb.overrideHostname` (with the full name ie: puppetdb.my.domain) and it's a workaround for now but you have to update the DNS config, for CoreDNS add the following line in the configMap:
+```
+rewrite name puppetdb.my.domain puppetdb.<namespace>.svc.cluster.local
+```
+
 ## Horizontal Scaling
 
 To achieve better availability and higher throughput of Puppet Infrastructure, you'll need to scale out Puppet Masters and/or Puppet Compilers.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -371,6 +371,32 @@ Create the name for the hiera eyaml public cert Secrets.
   eyamlpub-secret
 {{- end -}}
 
+{{/*
+Return the appropriate apiVersion for podsecuritypolicy.
+*/}}
+{{- define "podsecuritypolicy.apiVersion" -}}
+{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define puppetserver service Account name
+*/}}
+{{- define "puppetserver.puppetserver.serviceAccount.name" -}}
+{{ default "puppetserver" .Values.puppetserver.serviceAccount.accountName }}
+{{- end -}} 
+
+{{/*
+Define puppetdb service Account name
+*/}}
+{{- define "puppetserver.puppetdb.serviceAccount.name" -}}
+{{ default "puppetdb" .Values.puppetdb.serviceAccount.accountName }}
+{{- end -}}
+
+
 {{/* *************************************************************************************
 The following definitions were more complex and necessary during part of this development.
 Now they are essentially just stubs but left here in case they might be needed again soon.

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetserver.preGeneratedCertsJob.enabled }}
+{{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,6 +18,9 @@ spec:
         {{- include "puppetserver.puppet.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
+      {{- if .Values.puppetserver.serviceAccount.enabled }}
+      serviceAccountName: {{ include "puppetserver.puppetserver.serviceAccount.name" . }}
+      {{- end }}
       containers:
         - name: copy-ro-puppetserver-certs
           image: "{{.Values.puppetserver.image}}:{{.Values.puppetserver.tag}}"
@@ -25,26 +28,61 @@ spec:
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /etc/puppetlabs/puppet/ssl;
+              {{- if .Values.singleCA.enabled }}
+              mkdir -p /etc/puppetlabs/puppet/ssl/certs/;
+              mkdir -p /etc/puppetlabs/puppet/ssl/private_keys/;
+              cp /puppet-certs/puppetserver/ca.pem /etc/puppetlabs/puppet/ssl/certs/ca.pem;
+              cp /puppet-certs/puppetserver/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem /etc/puppetlabs/puppet/ssl/certs/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem;
+              cp /puppet-certs/puppetserver/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.key /etc/puppetlabs/puppet/ssl/private_keys/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem;
+              ls /puppet-certs/crl/;
+              cp /puppet-certs/crl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh;
+              cp /puppet-certs/crl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh;
+              cp /puppet-certs/crl/crl.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              chown puppet:puppet /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              chmod +x /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              {{- else }}
               CERTS_FILE=`ls /puppet-certs/puppetserver`;
               tar xf /puppet-certs/puppetserver/"$CERTS_FILE" -C /etc/puppetlabs/puppet/ssl;
+              {{- end }}
           volumeMounts:
             - name: puppetserver-certs
               mountPath: /puppet-certs/puppetserver
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
+            {{- if .Values.singleCA.enabled }}
+            - name: crl-volume
+              mountPath: /puppet-certs/crl
+            {{- end }}
         - name: copy-ro-puppetdb-certs
           image: "{{.Values.puppetdb.image}}:{{.Values.puppetdb.tag}}"
           imagePullPolicy: "{{.Values.puppetdb.pullPolicy}}"
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /opt/puppetlabs/server/data/puppetdb/certs;
+              {{- if .Values.singleCA.enabled }}
+              mkdir -p /opt/puppetlabs/server/data/puppetdb/certs/certs/;
+              mkdir -p /opt/puppetlabs/server/data/puppetdb/certs/private_keys/;
+              cp /puppet-certs/puppetdb/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem;
+              cp /puppet-certs/puppetdb/puppetdb.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/puppetdb.pem;
+              cp /puppet-certs/puppetdb/puppetdb.key /opt/puppetlabs/server/data/puppetdb/certs/private_keys/puppetdb.pem;
+              cp /puppet-crl/puppetdb/crl_entrypoint.sh /opt/puppetlabs/server/data/puppetdb/certs/crl_entrypoint.sh;
+              cp /puppet-crl/puppetdb/crl_cronjob.sh /opt/puppetlabs/server/data/puppetdb/certs/crl_cronjob.sh;
+              cp /puppet-crl/puppetdb/crl.sh /opt/puppetlabs/server/data/puppetdb/certs/crl.sh;
+              chown puppetdb:puppetdb /opt/puppetlabs/server/data/puppetdb/certs/crl_entrypoint.sh /opt/puppetlabs/server/data/puppetdb/certs/crl_cronjob.sh /opt/puppetlabs/server/data/puppetdb/certs/crl.sh;
+              chmod +x /opt/puppetlabs/server/data/puppetdb/certs/crl_entrypoint.sh /opt/puppetlabs/server/data/puppetdb/certs/crl_cronjob.sh /opt/puppetlabs/server/data/puppetdb/certs/crl.sh;
+              {{- else }}
               CERTS_FILE=`ls /puppet-certs/puppetdb`;
               tar xf /puppet-certs/puppetdb/"$CERTS_FILE" -C /opt/puppetlabs/server/data/puppetdb/certs --strip-components 1;
+              {{- end }}
           volumeMounts:
             - name: puppetdb-certs
               mountPath: /puppet-certs/puppetdb
             - name: puppetdb-storage
               mountPath: /opt/puppetlabs/server/data/puppetdb/certs
+            {{- if .Values.singleCA.enabled }}
+            - name: crl-volume
+              mountPath: /puppet-crl/puppetdb
+            {{- end }}
       volumes:
         - name: puppet-puppet-storage
         {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.puppet.enable }}
@@ -55,15 +93,30 @@ spec:
         {{- end }}
         - name: puppetdb-storage
         {{- if .Values.puppetdb.customPersistentVolumeClaim.storage.enable }}
-          {{- toYaml .Values.puppetserver.puppetdb.customPersistentVolumeClaim.storage.config | nindent 10 }}
+          {{- toYaml .Values.puppetdb.customPersistentVolumeClaim.storage.config | nindent 10 }}
         {{- else }}
           persistentVolumeClaim:
             claimName: puppetdb-claim
         {{- end }}
         - name: puppetserver-certs
+        {{- if not .Values.singleCA.enabled }}
           configMap:
             name: "{{ template "puppetserver.name" . }}-puppetserver-preinstall"
+        {{- else }}
+          secret:
+            secretName: {{ .Values.singleCA.certificates.existingSecret.puppetserver }}
+        {{- end }}
         - name: puppetdb-certs
+        {{- if not .Values.singleCA.enabled }}
           configMap:
             name: "{{ template "puppetserver.name" . }}-puppetdb-preinstall"
+        {{- else }}
+          secret:
+            secretName: {{ .Values.singleCA.certificates.existingSecret.puppetdb }}
+        {{- end }}
+        {{- if .Values.singleCA.enabled }}
+        - name: crl-volume
+          configMap:
+            name: crl-config
+        {{- end }}
 {{- end }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       hostname: puppetdb
       {{- if .Values.puppetdb.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.puppetdb.serviceAccount.accountName }}
+      serviceAccountName: {{ include "puppetserver.puppetdb.serviceAccount.name" . }}
       {{- end }}
       containers:
         {{- with .Values.puppetdb.extraContainers }}
@@ -80,7 +80,7 @@ spec:
             {{- toYaml .Values.puppetboard.resources | nindent 12 }}
           env:
             - name: PUPPETDB_HOST
-              value: "puppetdb"
+              value: "{{ .Values.singleCA.puppetdb.overrideHostname | default "puppetdb"  }}"
             - name: PUPPETDB_PORT
               value: "8081"
             - name: PUPPETDB_SSL_VERIFY
@@ -105,6 +105,48 @@ spec:
           volumeMounts:
             - name: puppetdb-storage
               mountPath: /opt/puppetlabs/server/data/puppetdb/certs
+        {{- end }}
+        {{- if .Values.singleCA.enabled }}
+        # singleCA crl script update Sidecar
+        - name: update-crl
+          image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
+          imagePullPolicy: "{{.Values.r10k.pullPolicy}}"
+          resources:
+            {{- toYaml .Values.singleCA.resources | nindent 12 }}
+          env:
+          - name: SSL_PATH
+            value: /opt/puppetlabs/server/data/puppetdb/certs
+          {{- if .Values.singleCA.crl.credential }}
+          - name: CRL_CREDS_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.singleCA.crl.credential.existingSecret }}
+                key: username
+          - name: CRL_CREDS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.singleCA.crl.credential.existingSecret }}
+                key: password
+          {{- end }}
+          {{- range $key, $value := .Values.singleCA.extraEnv }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+          {{- end }}
+          command: ["sh", "-c", "/opt/puppetlabs/server/data/puppetdb/certs/crl_entrypoint.sh" ]
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            runAsGroup: 999 # "puppet" GID
+          volumeMounts:
+          - name: puppetdb-storage
+            mountPath: /opt/puppetlabs/server/data/puppetdb/certs
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-ec", "test -f ~/.crl_cronjob.success"]
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
         {{- end }}
       volumes:
         - name: puppetdb-storage

--- a/templates/puppetdb-preInstall.configMap.yaml
+++ b/templates/puppetdb-preInstall.configMap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetserver.preGeneratedCertsJob.enabled }}
+{{- if and (.Values.puppetserver.preGeneratedCertsJob.enabled) (not .Values.singleCA.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/puppetdb-pvc.yaml
+++ b/templates/puppetdb-pvc.yaml
@@ -6,10 +6,10 @@ metadata:
   name: puppetdb-claim
   labels:
     {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
-  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.storage.annotations) }}
+  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) (.Values.storage.annotations) }}
   annotations:
   {{- end }}
-    {{- if .Values.puppetserver.preGeneratedCertsJob.enabled }}
+    {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -22,13 +22,14 @@ spec:
         {{- include "puppetserver.puppetserver.labels" . | nindent 8 }}
       annotations:
         checksum/hiera-configmap: {{ include (print $.Template.BasePath "/hiera-configmap.yaml") . | sha256sum }}
+        checksum/crl-config: {{ include (print $.Template.BasePath "/update-crl-configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       hostname: {{ template "puppetserver.puppetserver-masters.serviceName" . }}
       {{- if .Values.puppetserver.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.puppetserver.serviceAccount.accountName }}
+      serviceAccountName: {{ include "puppetserver.puppetserver.serviceAccount.name" . }}
       {{- end }}
       initContainers:
         - name: perms-and-dirs
@@ -46,7 +47,7 @@ spec:
             - name: PUPPET_DATA_DIR
               value: "/etc/puppetlabs/code/environments"
             - name: PUPPET_SSL_CERT_PEM
-              value: "/etc/puppetlabs/puppet/ssl/certs/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem"
+              value: "/etc/puppetlabs/puppet/ssl/certs/{{ (include "puppetserver.puppetserver-masters.serviceName" . ) }}.pem"
           {{- end }}
           command: [ "sh", "-c" ]
           args:
@@ -81,11 +82,18 @@ spec:
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
-              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) -}}
+              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
+              {{- end }}
+              {{- if .Values.singleCA.enabled }}
+              cp /etc/puppetlabs/puppet/configmap/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh;
+              cp /etc/puppetlabs/puppet/configmap/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh;
+              cp /etc/puppetlabs/puppet/configmap/crl.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              chown puppet:puppet /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              chmod +x /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
               {{- end }}
           securityContext:
             runAsUser: 0
@@ -131,7 +139,7 @@ spec:
             - name: manifests-volume
               mountPath: /etc/puppetlabs/puppet/configmap/site.pp
               subPath: site.pp
-            {{- if and (.Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingSecret) }}
+            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
             {{- end }}
@@ -142,6 +150,17 @@ spec:
             - name: eyamlpriv-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
+            {{- end }}
+            {{- if .Values.singleCA.enabled }}
+            - name: crl-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/crl_entrypoint.sh
+              subPath: crl_entrypoint.sh
+            - name: crl-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/crl_cronjob.sh
+              subPath: crl_cronjob.sh
+            - name: crl-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/crl.sh
+              subPath: crl.sh
             {{- end }}
       containers:
         - name: {{ template "puppetserver.fullname" . }}
@@ -156,14 +175,18 @@ spec:
             {{- end }}
             # necessary to set certname and server in puppet.conf, required by
             # puppetserver ca cli application
+            {{- if .Values.singleCA.enabled }}
+            - name: CA_ENABLED
+              value: "false"
+            {{- end }}
             - name: PUPPETSERVER_HOSTNAME
-              value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
+              value: {{ (include "puppetserver.puppetserver-masters.serviceName" . | quote ) }}
             - name: PUPPET_MASTERPORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
               value: "{{ if .Values.puppetserver.compilers.fqdns.alternateServerNames }}{{ template "puppetserver.compilers.hostnames" . }},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}},{{ end }}{{ template "puppetserver.puppetserver.agents-to-masters.serviceName" . }},{{.Values.puppetserver.masters.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS
-              value: "https://puppetdb:8081"
+              value: "https://{{ default "puppetdb" .Values.singleCA.puppetdb.overrideHostname }}:8081"
             - name: CA_ALLOW_SUBJECT_ALT_NAMES
               value: "true"
           readinessProbe:
@@ -281,6 +304,48 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         {{- end }}
+        {{- if .Values.singleCA.enabled }}
+        # singleCA crl script update Sidecar
+        - name: update-crl
+          image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
+          imagePullPolicy: "{{.Values.r10k.pullPolicy}}"
+          resources:
+            {{- toYaml .Values.singleCA.resources | nindent 12 }}
+          env:
+          - name: SSL_PATH
+            value: /etc/puppetlabs/puppet/ssl
+          {{- if .Values.singleCA.crl.credential }}
+          - name: CRL_CREDS_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.singleCA.crl.credential.existingSecret }}
+                key: username
+          - name: CRL_CREDS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.singleCA.crl.credential.existingSecret }}
+                key: password
+          {{- end }}
+          {{- range $key, $value := .Values.singleCA.extraEnv }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+          {{- end }}
+          command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ]
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            runAsGroup: 999 # "puppet" GID
+          volumeMounts:
+          - name: puppet-puppet-storage
+            mountPath: /etc/puppetlabs/puppet/
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-ec", "test -f ~/.crl_cronjob.success"]
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
+        {{- end }}
       securityContext:
         fsGroup: 999   # "puppet" GID
       volumes:
@@ -304,6 +369,11 @@ spec:
         {{- else }}
           persistentVolumeClaim:
             claimName: puppet-puppet-claim
+        {{- end }}
+        {{- if .Values.singleCA.enabled }}
+        - name: crl-volume
+          configMap:
+            name: crl-config
         {{- end }}
         - name: puppet-serverdata-storage
         {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.serverdata.enable }}

--- a/templates/puppetserver-podsecuritypolicy.yaml
+++ b/templates/puppetserver-podsecuritypolicy.yaml
@@ -4,10 +4,17 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ default "puppetserver" .Values.puppetserver.serviceAccount.accountName }}-psp
   namespace: {{ .Release.Namespace }}
+  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) (.Values.storage.annotations) }}
   annotations:
+  {{- end }}
+    {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-10"
+    {{- end }}
+    {{- if .Values.storage.annotations }}
+    {{ toYaml .Values.storage.annotations }}
+    {{- end }}
 spec:
   privileged: true
   volumes:

--- a/templates/puppetserver-preInstall.configMap.yaml
+++ b/templates/puppetserver-preInstall.configMap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetserver.preGeneratedCertsJob.enabled }}
+{{- if and (.Values.puppetserver.preGeneratedCertsJob.enabled) (not .Values.singleCA.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/puppetserver-pvc.yaml
+++ b/templates/puppetserver-pvc.yaml
@@ -6,10 +6,10 @@ metadata:
   name: puppet-puppet-claim
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.storage.annotations) }}
+  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) (.Values.storage.annotations) }}
   annotations:
   {{- end }}
-    {{- if .Values.puppetserver.preGeneratedCertsJob.enabled }}
+    {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/templates/puppetserver-role.yaml
+++ b/templates/puppetserver-role.yaml
@@ -4,10 +4,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ default "puppetserver" .Values.puppetserver.serviceAccount.accountName }}-role
   namespace: {{ .Release.Namespace }}
+  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) (.Values.storage.annotations) }}
   annotations:
+  {{- end }}
+    {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-10"
+    {{- end }}
+    {{- if .Values.storage.annotations }}
+    {{ toYaml .Values.storage.annotations }}
+    {{- end }}
 rules:
   {{- if .Values.puppetserver.psp.create }}
   - apiGroups: ["extensions"]

--- a/templates/puppetserver-rolebinding.yaml
+++ b/templates/puppetserver-rolebinding.yaml
@@ -4,10 +4,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ default "puppetserver" .Values.puppetserver.serviceAccount.accountName }}-rb
   namespace: {{ .Release.Namespace }}
+  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) (.Values.storage.annotations) }}
   annotations:
+  {{- end }}
+    {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-10"
+    {{- end }}
+    {{- if .Values.storage.annotations }}
+    {{ toYaml .Values.storage.annotations }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/templates/puppetserver-serviceaccount.yaml
+++ b/templates/puppetserver-serviceaccount.yaml
@@ -4,8 +4,15 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.puppetserver.serviceAccount.accountName | default "puppet" }}
   namespace: {{ .Release.Namespace }}
+  {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) (.Values.storage.annotations) }}
   annotations:
+  {{- end }}
+    {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-10"
+    {{- end }}
+    {{- if .Values.storage.annotations }}
+    {{ toYaml .Values.storage.annotations }}
+    {{- end }}
 {{- end }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -27,12 +27,13 @@ spec:
         {{- include "puppetserver.puppetserver-compilers.labels" . | nindent 8 }}
       annotations:
         checksum/hiera-configmap: {{ include (print $.Template.BasePath "/hiera-configmap.yaml") . | sha256sum }}
+        checksum/crl-config: {{ include (print $.Template.BasePath "/update-crl-configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.puppetserver.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.puppetserver.serviceAccount.accountName }}
+      serviceAccountName: {{ include "puppetserver.puppetserver.serviceAccount.name" . }}
       {{- end }}
       initContainers:
         - name: perms-and-dirs
@@ -72,11 +73,23 @@ spec:
               {{- end }}
               cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
-              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) -}}
+              {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
+              {{- end }}
+              {{- if .Values.singleCA.enabled }}
+              mkdir -p /etc/puppetlabs/puppet/ssl/certs/;
+              mkdir -p /etc/puppetlabs/puppet/ssl/private_keys/;
+              cp /puppet-certs/puppetserver/ca.pem /etc/puppetlabs/puppet/ssl/certs/ca.pem;
+              cp /puppet-certs/puppetserver/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem /etc/puppetlabs/puppet/ssl/certs/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem;
+              cp /puppet-certs/puppetserver/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.key /etc/puppetlabs/puppet/ssl/private_keys/{{ template "puppetserver.puppetserver-masters.serviceName" . }}.pem;
+              cp /etc/puppetlabs/puppet/configmap/crl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh;
+              cp /etc/puppetlabs/puppet/configmap/crl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh;
+              cp /etc/puppetlabs/puppet/configmap/crl/crl.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              chown puppet:puppet /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
+              chmod +x /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
               {{- end }}
           securityContext:
             runAsUser: 0
@@ -117,7 +130,7 @@ spec:
             - name: manifests-volume
               mountPath: /etc/puppetlabs/puppet/configmap/site.pp
               subPath: site.pp
-            {{- if and (.Values.hiera.eyaml.existingMap) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) (not .Values.hiera.eyaml.existingSecret) }}
+            {{- if and ( or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
             {{- end }}
@@ -128,6 +141,12 @@ spec:
             - name: eyamlpriv-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
+            {{- end }}
+            {{- if .Values.singleCA.enabled }}
+            - name: crl-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/crl
+            - name: puppetserver-certs
+              mountPath: /puppet-certs/puppetserver
             {{- end }}
       containers:
         - name: {{ template "puppetserver.fullname" . }}
@@ -143,15 +162,19 @@ spec:
             # necessary to set certname and server in puppet.conf, required by
             # puppetserver ca cli application
             - name: PUPPETSERVER_HOSTNAME
+              {{- if .Values.singleCA.enabled }}
+              value: {{ (include "puppetserver.puppetserver-masters.serviceName" . | quote ) }}
+              {{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+              {{- end }}
             - name: PUPPET_MASTERPORT
               value: "{{ template "puppetserver.puppetserver-compilers.port" . }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS
-              value: "https://puppetdb:8081"
+              value: "https://{{ default "puppetdb" .Values.singleCA.puppetdb.overrideHostname }}:8081"
             - name: CA_ENABLED
               value: "false"
             - name: CA_HOSTNAME
@@ -269,6 +292,48 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         {{- end }}
+        {{- if .Values.singleCA.enabled }}
+        # singleCA crl script update Sidecar
+        - name: update-crl
+          image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
+          imagePullPolicy: "{{.Values.r10k.pullPolicy}}"
+          resources:
+            {{- toYaml .Values.singleCA.resources | nindent 12 }}
+          env:
+          - name: SSL_PATH
+            value: /etc/puppetlabs/puppet/ssl
+          {{- if .Values.singleCA.crl.credential }}
+          - name: CRL_CREDS_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.singleCA.crl.credential.existingSecret }}
+                key: username
+          - name: CRL_CREDS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.singleCA.crl.credential.existingSecret }}
+                key: password
+          {{- end }}
+          {{- range $key, $value := .Values.singleCA.extraEnv }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+          {{- end }}
+          command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ]
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            runAsGroup: 999 # "puppet" GID
+          volumeMounts:
+          - name: puppet-puppet-volume
+            mountPath: /etc/puppetlabs/puppet/
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-ec", "test -f ~/.crl_cronjob.success"]
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
+        {{- end }}
       securityContext:
         fsGroup: 999   # "puppet" GID
       volumes:
@@ -276,6 +341,19 @@ spec:
         - name: hiera-volume
           configMap:
             name: hiera-config
+        {{- end }}
+        {{- if .Values.singleCA.enabled }}
+        - name: crl-volume
+          configMap:
+            name: crl-config
+        - name: puppetserver-certs
+        {{- if not .Values.singleCA.enabled }}
+          configMap:
+            name: "{{ template "puppetserver.name" . }}-puppetserver-preinstall"
+        {{- else }}
+          secret:
+            secretName: {{ .Values.singleCA.certificates.existingSecret.puppetserver }}
+        {{- end }}
         {{- end }}
         - name: manifests-volume
           configMap:

--- a/templates/update-crl-configmap.yaml
+++ b/templates/update-crl-configmap.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.singleCA.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crl-config
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+data:
+  crl.sh: |-
+    {{- if .Values.singleCA.config }}
+    {{ .Values.singleCA.config | nindent 6 }}
+    {{- else }}
+    #!/usr/bin/env sh
+    url={{ required "A valid .Values.singleCA.crl.url required!" .Values.singleCA.crl.url }}
+    cred="-u {{- if .Values.singleCA.crl.credential }}$CRL_CREDS_USERNAME:$CRL_CREDS_PASSWORD{{- end }}"
+    
+    curl $cred -s -O $url
+    retVal=$?
+
+    mv crl.pem $SSL_PATH/crl.pem
+    grep -q "BEGIN X509 CRL" "$SSL_PATH/crl.pem" > /dev/null 2>&1
+    grepVal=$?
+
+    if [[ "$retVal" -ne "0" || "$grepVal" -ne "0" ]]; then
+      rm ~/.crl_cronjob.success > /dev/null 2>&1
+      retVal=1
+    else
+      touch ~/.crl_cronjob.success > /dev/null 2>&1
+    fi
+
+    exit $retVal
+    {{- end }}
+    
+  crl_cronjob.sh: |
+    #!/usr/bin/env sh
+    $SSL_PATH/crl.sh > ~/.crl_cronjob.out 2>&1
+    retVal=$?
+    if [ "$retVal" -eq "0" ]; then
+      touch ~/.crl_cronjob.success > /dev/null 2>&1
+    else
+      rm ~/.crl_cronjob.success > /dev/null 2>&1
+    fi
+
+    exit $retVal
+
+  crl_entrypoint.sh: |
+    #!/usr/bin/env sh
+    set -e
+    if [ ! -f $SSL_PATH/crl.pem ]; then
+      /bin/sh -c $SSL_PATH/crl_cronjob.sh
+    fi
+    cat > ~/.crl_crontab <<'EOF'
+    {{ .Values.singleCA.cronJob.schedule }} /bin/sh -c $SSL_PATH/crl_cronjob.sh
+    EOF
+    # tail -Fq ~/.crl_cronjob.out &
+    touch ~/.crl_cronjob.success > /dev/null 2>&1
+    exec supercronic ~/.crl_crontab
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -680,3 +680,32 @@ storage:
   ##
   annotations: {}
   size: 400Mi
+
+singleCA:
+  enabled: false
+  cronJob: 
+    schedule: "* 0 * * * *"
+  crl:
+    url:
+    credential:
+      existingSecret:
+  # crl:
+    # url:
+    # credential:
+    #   existingSecret:
+  extraEnv: {}
+  resources: {}
+    #  requests:
+    #    memory: 128Mi
+    #    cpu: 50m
+    #  limits:
+    #    memory: 2048Mi
+    #    cpu: 100m
+  config: ''
+  certificates:
+    existingSecret: {}
+    #   puppetserver:
+    #   puppetdb:
+  puppetdb:
+    overrideHostname: ''
+


### PR DESCRIPTION
- feat: Single CA support (https://puppet.com/docs/puppet/7/config_ssl_external_ca.html)
- fix: define `podsecuritypolicy.apiVersion`
- fix copy issue with eyaml keys when use `existingSecret`
- fix puppetdb volume issue when use `customPersistentVolumeClaim`
- refactoring serviceAccount name