### PR TITLE
bump postgresql chart dependency, remove helm v2 support, improve puppetserver startup. allow overriding harcoded variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.1.0) (2022-06-07)
+
+- fix: postgresql dependency. bump from `10.4.*` to `10.16.*` (https://github.com/bitnami/charts/issues/10539)
+- feat: drop Helm chart v2 support
+- feat: improve puppetserver (master & compiler) startup with `startupProbe`
+- feat: allow overriding harcoded variables
+
 ## [v6.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.0.0) (2022-06-01)
 
 - feat: Single CA support (https://puppet.com/docs/puppet/7/config_ssl_external_ca.html)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: puppetserver
-version: 6.0.0
+version: 6.1.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 
   - name: postgresql
-    version: "10.4.*"
+    version: "10.16.*"
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -34,10 +34,6 @@ spec:
           resources:
             {{- toYaml .Values.puppetdb.resources | nindent 12 }}
           env:
-            {{- range $key, $value := .Values.puppetdb.extraEnv }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
             - name: PUPPETSERVER_HOSTNAME
               value: "puppet"
             - name: PUPPETSERVER_PORT
@@ -56,6 +52,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "puppetdb.secret" . }}
                   key: username
+            {{- range $key, $value := .Values.puppetdb.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           ports:
             - name: pdb-http
               containerPort: 8080

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -169,10 +169,6 @@ spec:
           resources:
             {{- toYaml .Values.puppetserver.masters.resources | nindent 12 }}
           env:
-            {{- range $key, $value := .Values.puppetserver.masters.extraEnv }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
             # necessary to set certname and server in puppet.conf, required by
             # puppetserver ca cli application
             {{- if .Values.singleCA.enabled }}
@@ -189,12 +185,15 @@ spec:
               value: "https://{{ default "puppetdb" .Values.singleCA.puppetdb.overrideHostname }}:8081"
             - name: CA_ALLOW_SUBJECT_ALT_NAMES
               value: "true"
+            {{- range $key, $value := .Values.puppetserver.masters.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /status/v1/simple
               port: {{ template "puppetserver.puppetserver-masters.port" .}}
               scheme: HTTPS
-            initialDelaySeconds: {{ .Values.puppetserver.masters.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.masters.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.masters.readinessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.masters.readinessProbeFailureThreshold }}
@@ -202,11 +201,15 @@ spec:
           livenessProbe:
             tcpSocket:
               port: {{ template "puppetserver.puppetserver-masters.port" .}}
-            initialDelaySeconds: {{ .Values.puppetserver.masters.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.masters.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.masters.livenessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.masters.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.puppetserver.masters.livenessProbeSuccessThreshold }}
+          startupProbe:
+            tcpSocket:
+              port: {{ template "puppetserver.puppetserver-masters.port" .}}
+            periodSeconds: {{ .Values.puppetserver.masters.startupProbePeriodSeconds }}
+            failureThreshold: {{ .Values.puppetserver.masters.startupProbeFailureThreshold }}
           ports:
             - containerPort: {{ template "puppetserver.puppetserver-masters.port" .}}
           volumeMounts:

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -155,10 +155,6 @@ spec:
           resources:
             {{- toYaml .Values.puppetserver.compilers.resources | nindent 12 }}
           env:
-            {{- range $key, $value := .Values.puppetserver.compilers.extraEnv }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
             # necessary to set certname and server in puppet.conf, required by
             # puppetserver ca cli application
             - name: PUPPETSERVER_HOSTNAME
@@ -181,12 +177,15 @@ spec:
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
             - name: CA_MASTERPORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
+            {{- range $key, $value := .Values.puppetserver.compilers.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /status/v1/simple
               port: {{ template "puppetserver.puppetserver-compilers.port" . }}
               scheme: HTTPS
-            initialDelaySeconds: {{ .Values.puppetserver.compilers.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.compilers.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.compilers.readinessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.compilers.readinessProbeFailureThreshold }}
@@ -194,11 +193,15 @@ spec:
           livenessProbe:
             tcpSocket:
               port: {{ template "puppetserver.puppetserver-compilers.port" . }}
-            initialDelaySeconds: {{ .Values.puppetserver.compilers.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.puppetserver.compilers.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.compilers.livenessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.compilers.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.puppetserver.compilers.livenessProbeSuccessThreshold }}
+          startupProbe:
+            tcpSocket:
+              port: {{ template "puppetserver.puppetserver-compilers.port" . }}
+            periodSeconds: {{ .Values.puppetserver.compilers.startupProbePeriodSeconds }}
+            failureThreshold: {{ .Values.puppetserver.compilers.startupProbeFailureThreshold }}
           ports:
             - containerPort: {{ template "puppetserver.puppetserver-compilers.port" . }}
           volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -36,16 +36,17 @@ puppetserver:
     ## Puppet Server Master readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
-    readinessProbeInitialDelay: 180
     readinessProbePeriodSeconds: 60
     readinessProbeTimeout: 20
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
-    livenessProbeInitialDelay: 420
     livenessProbePeriodSeconds: 30
     livenessProbeTimeout: 10
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1
+    startupProbePeriodSeconds: 15
+    startupProbeFailureThreshold: 30
+
 
     ## Fully qualified domain names (FQDN's) to register
     ## the Puppet Server Masters to be internally reachable via DNS.
@@ -180,16 +181,16 @@ puppetserver:
     ## Puppet Server Compiler readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ##
-    readinessProbeInitialDelay: 180
     readinessProbePeriodSeconds: 60
     readinessProbeTimeout: 20
     readinessProbeFailureThreshold: 3
     readinessProbeSuccessThreshold: 1
-    livenessProbeInitialDelay: 420
     livenessProbePeriodSeconds: 30
     livenessProbeTimeout: 10
     livenessProbeFailureThreshold: 3
     livenessProbeSuccessThreshold: 1
+    startupProbePeriodSeconds: 15
+    startupProbeFailureThreshold: 30
 
     ## Horizontal Pod Manual Scaling for Puppet Server Compilers
     ## Set the desired number of Puppet Server Compilers


### PR DESCRIPTION
- fix: postgresql dependency. bump from `10.4.*` to `10.16.*` (https://github.com/bitnami/charts/issues/10539)
- feat: drop Helm chart v2 support
- feat: improve puppetserver (master & compiler) startup with `startupProbe`
- feat: allow overriding harcoded variables