### PR TITLE
added r10k.code.cronJob.successFile param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.3.0) (2022-06-29)
+
+- feat: add `extraContainers` to both masters and compilers
+- feat: add r10k cron job `successFile` params
+
 ## [v6.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.2.0) (2022-06-08)
 
 - feat: update labels (match with Well-Known Labels) & add `extraLabels`

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.2.0
+version: 6.3.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.code.resources` | r10k control repo resource limits |``|
 | `r10k.code.cronJob.enabled` | enable or disable r10k control repo cron job schedule policy | `true`|
 | `r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`|
+| `r10k.code.cronJob.successFile` | path to file reflecting success of r10k control repo cron job | `~/.r10k_code_cronjob.success`|
 | `r10k.code.extraArgs` | r10k control repo additional container env args |``|
 | `r10k.code.extraEnv` | r10k control repo additional container env vars |``|
 | `r10k.code.viaSsh.credentials.ssh.value`| r10k control repo ssh key file |``|
@@ -247,6 +248,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.hiera.resources` | r10k hiera data resource limits |``|
 | `r10k.hiera.cronJob.enabled` | enable or disable r10k hiera data cron job schedule policy | `true`|
 | `r10k.hiera.cronJob.schedule` | r10k hiera data cron job schedule policy | `*/2 * * * *`|
+| `r10k.hiera.cronJob.successFile` | path to file reflecting success of r10k hiera data cron job | `~/.r10k_hiera_cronjob.success`|
 | `r10k.hiera.extraArgs` | r10k hiera data additional container env args |``|
 | `r10k.hiera.extraEnv` | r10k hiera data additional container env vars |``|
 | `r10k.hiera.viaSsh.credentials.ssh.value`| r10k hiera data ssh key file |``|

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -262,7 +262,7 @@ spec:
             mountPath: /etc/puppetlabs/puppet/
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f ~/.r10k_code_cronjob.success"]
+              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.code.cronJob.successFile }}"]
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20
@@ -305,7 +305,7 @@ spec:
             mountPath: /etc/puppetlabs/puppet/
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f ~/.r10k_hiera_cronjob.success"]
+              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.hiera.cronJob.successFile }}"]
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -250,7 +250,7 @@ spec:
             mountPath: /etc/puppetlabs/puppet/
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f ~/.r10k_code_cronjob.success"]
+              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.code.cronJob.successFile }}"]
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20
@@ -293,7 +293,7 @@ spec:
             mountPath: /etc/puppetlabs/puppet/
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f ~/.r10k_hiera_cronjob.success"]
+              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.hiera.cronJob.successFile }}"]
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -24,9 +24,9 @@ data:
     --puppetfile {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then
-      touch ~/.r10k_code_cronjob.success > /dev/null 2>&1
+      touch {{ .Values.r10k.code.cronJob.successFile }} > /dev/null 2>&1
     else
-      rm ~/.r10k_code_cronjob.success > /dev/null 2>&1
+      rm {{ .Values.r10k.code.cronJob.successFile }} > /dev/null 2>&1
     fi
     exit $retVal
 
@@ -39,7 +39,7 @@ data:
     EOF
     tail -Fq ~/.r10k_code_cronjob.out &
     {{- end }}
-    touch ~/.r10k_code_cronjob.success > /dev/null 2>&1
+    touch {{ .Values.r10k.code.cronJob.successFile }} > /dev/null 2>&1
     {{- if .Values.r10k.code.cronJob.enabled }}
     exec supercronic ~/.r10k_code_crontab
     {{- else}}

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -29,9 +29,9 @@ data:
     --puppetfile {{ template "r10k.hiera.args" . }} > ~/.r10k_hiera_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then
-      touch ~/.r10k_hiera_cronjob.success > /dev/null 2>&1
+      touch {{ .Values.r10k.hiera.cronJob.successFile }} > /dev/null 2>&1
     else
-      rm ~/.r10k_hiera_cronjob.success > /dev/null 2>&1
+      rm {{ .Values.r10k.hiera.cronJob.successFile }} > /dev/null 2>&1
     fi
     exit $retVal
 
@@ -44,7 +44,7 @@ data:
     EOF
     tail -Fq ~/.r10k_hiera_cronjob.out &
     {{- end }}
-    touch ~/.r10k_hiera_cronjob.success > /dev/null 2>&1
+    touch {{ .Values.r10k.hiera.cronJob.successFile }} > /dev/null 2>&1
     {{- if .Values.r10k.hiera.cronJob.enabled }}
     exec supercronic ~/.r10k_hiera_crontab
     {{- else}}

--- a/values.yaml
+++ b/values.yaml
@@ -331,6 +331,7 @@ r10k:
     cronJob:
       enabled: true
       schedule: "*/5 * * * *"
+      successFile: ~/.r10k_code_cronjob.success
     ## Additional r10k code container arguments
     extraArgs: []
     #   - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
@@ -374,6 +375,7 @@ r10k:
     cronJob:
       enabled: true
       schedule: "*/4 * * * *"
+      successFile: ~/.r10k_hiera_cronjob.success
     ## Additional r10k hiera container environment variables
     extraArgs: []
     #   - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2


### PR DESCRIPTION
In my setup I need the file reflecting whether the r10k code cronjob succeeded on a different volume, this change allows me to easily adjust this. Same thing goes for the hiera cronjob.