### PR TITLE
various improvements so that foreman relevant configuration can be injected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.0) (2022-07-29)
+
+- feat: optional deployment of the puppetdb component (default true)
+- feat: remove privileged from securityContext (I do not understand why it was used/needed??)
+- feat: inject custom entrypoints which will be exuected during puppetserver startup
+- feat: inject custom configmaps to configure puppetserver itself (configmaps mounted in /etc/puppetlabs/puppetserver/conf.d)
+- feat: support extra r10k hiera & code repositories
+- fix: use r10k code & hiera extrasettings as map (global r10k configuration can be injected this way)
+- fix: puppet service configured as ClusterIP only.
+- fix: if compilers are deployed remove r10k container & code volumes from masters
+
 ## [v6.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.4.0) (2022-06-30)
 
 - feat: add r10k cron job `splay`, `splayLimit` and `timeout` params

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - feat: inject custom entrypoints which will be exuected during puppetserver startup
 - feat: inject custom configmaps to configure puppetserver itself (configmaps mounted in /etc/puppetlabs/puppetserver/conf.d)
 - feat: support extra r10k hiera & code repositories
+- feat: add a restic backup Cronjob to backup our puppetserver master pv's
 - fix: use r10k code & hiera extrasettings as map (global r10k configuration can be injected this way)
 - fix: puppet service configured as ClusterIP only.
 - fix: if compilers are deployed remove r10k container & code volumes from masters

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.4.0
+version: 6.5.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.serviceAccount.create`| puppetserver additional masters svc labels |`false`|
 | `puppetserver.rbac.create`| Enable PodSecurityPolicy's RBAC rules |`false`|
 | `puppetserver.psp.create`| Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later |`false`|
+| `puppetserver.customconfigs.enabled`| puppetserver additional config map enabled |`false`|
+| `puppetserver.customconfigs.configmaps`| puppetserver additional config maps which will be mounted in /etc/puppetlab/puppetserver/conf.d/ |``|
+| `puppetserver.customentrypoints.enabled`| puppetserver additional entrypoint scripts. will be executed before puppetserver launch |`false`|
+| `puppetserver.customentrypoints.configmaps`| puppetserver additional configmaps |``|
+| `puppetserver.extraSecrets`| puppetserver additional secret which will be mounted in pod |``|
+| `puppetserver.extraInitArgs`| puppetserver additional initArgs |``|
 | `r10k.name` | r10k component label | `r10k`|
 | `r10k.image` | r10k img | `puppet/r10k`|
 | `r10k.tag` | r10k img tag | `3.5.1`|
@@ -274,6 +280,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `postgresql.persistence.annotations` | postgres persistence resource policy via annotations |`keep`|
 | `postgresql.replication.enabled` | postgres replication availability |`false`|
 | `postgresql.replication.slaveReplicas` | postgres replication slave replicas |`1`|
+| `puppetdb.enabled` | puppetdb component enabled |`true`|
 | `puppetdb.name` | puppetdb component label | `puppetdb`|
 | `puppetdb.image` | puppetdb img | `puppet/puppetdb`|
 | `puppetdb.tag` | puppetdb img tag | `6.12.0`|
@@ -415,3 +422,4 @@ kill %[job_numbers_above]
 * [Manasseh MMadu](https://github.com/mensaah), Contributor
 * [Aidan](https://github.com/artificial-aidan), Contributor
 * [Aurélien Le Clainche](https://www.linkedin.com/in/aurelien-le-clainche/), Contributor
+* [Simon Fuhrer](https://github.com/simonfuhrer), Contributor

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.masters.customPersistentVolumeClaim.code.config`| Configuration for custom PVC for code |``|
 | `puppetserver.masters.customPersistentVolumeClaim.serverdata.enable`| If true, use custom PVC for serverdata  |``|
 | `puppetserver.masters.customPersistentVolumeClaim.serverdata.config`| Configuration for custom PVC for serverdata |``|
+| `puppetserver.masters.backup.enabled` | If true, enable master backup with a kubernetes CronJob and restic | `false`|
+| `puppetserver.masters.backup.resources` | puppetserver restic backup CronJob resource limits | ``|
+| `puppetserver.masters.backup.failedJobsHistoryLimit` | puppetserver restic backup CronJob failedJobsHistoryLimit | `5`|
+| `puppetserver.masters.backup.successfulJobsHistoryLimit` | puppetserver restic backup CronJob successfulJobsHistoryLimit | `2`|
+| `puppetserver.masters.backup.schedule` | puppetserver restic backup CronJob schedule | `@every 12h`|
+| `puppetserver.masters.backup.image` | puppetserver restic backup CronJob image | `restic/restic`|
+| `puppetserver.masters.backup.tag` | puppetserver restic backup CronJob image tag | `0.13.1`|
+| `puppetserver.masters.backup.pullPolicy` | puppetserver restic backup CronJob image pullPolicy | `IfNotPresent`|
+| `puppetserver.masters.backup.restic.keep_last` | puppetserver restic backup CronJob keep last n days | `90`|
+| `puppetserver.masters.backup.restic.repository` | puppetserver restic backup CronJob s3 compatible repository | ``|
+| `puppetserver.masters.backup.restic.access_key_id` | puppetserver restic backup CronJob s3 access_key_id | ``|
+| `puppetserver.masters.backup.restic.secret_access_key` | puppetserver restic backup CronJob s3 secret_access_key | ``|
+| `puppetserver.masters.backup.restic.password` | puppetserver restic backup CronJob encryption password  | ``|
 | `puppetserver.compilers.enabled` | If true, creates Puppetserver compilers | `false`|
 | `puppetserver.compilers.resources` | puppetserver compilers resource limits |``|
 | `puppetserver.compilers.podAntiAffinity` | puppetserver compilers pod affinity constraints |`false`|

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.puppetdb.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -104,7 +105,6 @@ spec:
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
-            privileged: true
           volumeMounts:
             - name: puppetdb-storage
               mountPath: /opt/puppetlabs/server/data/puppetdb/certs
@@ -192,3 +192,4 @@ spec:
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+{{- end }}

--- a/templates/puppetdb-metrics-configmap.yaml
+++ b/templates/puppetdb-metrics-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetdb.metrics.enabled }}
+{{- if and (.Values.puppetdb.enabled) (.Values.puppetdb.metrics.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/puppetdb-podsecuritypolicy.yaml
+++ b/templates/puppetdb-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetdb.psp.create }}
+{{- if and (.Values.puppetdb.enabled) (.Values.puppetdb.psp.create) }}
 apiVersion: {{ include "podsecuritypolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:

--- a/templates/puppetdb-pvc.yaml
+++ b/templates/puppetdb-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.puppetdb.enabled }}
 {{- if .Values.puppetdb.customPersistentVolumeClaim.storage.enable }}
 {{- else }}
 apiVersion: v1
@@ -30,4 +31,5 @@ spec:
   storageClassName: "{{ .Values.storage.storageClass }}"
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/puppetdb-rolebinding.yaml
+++ b/templates/puppetdb-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.puppetdb.rbac.create }}
+{{- if and (.Values.puppetdb.enabled) (.Values.puppetdb.rbac.create) }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/templates/puppetdb-service.yaml
+++ b/templates/puppetdb-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.puppetdb.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,3 +34,4 @@ spec:
   {{- if (and (eq .Values.puppetdb.service.type "LoadBalancer") (not (empty .Values.puppetdb.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.puppetdb.service.loadBalancerIP }}
   {{- end }}
+{{- end }}

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.puppetserver.masters.backup.enabled (not .Values.singleCA.enabled) }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "puppetserver.name" . }}-puppetserver-master-backup
+  labels:
+    {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
+    {{- with .Values.puppetserver.masters.extraLabels }}
+    {{ toYaml . | indent 6 }}
+    {{- end }}
+spec:
+  concurrencyPolicy: Forbid
+  suspend: false
+  failedJobsHistoryLimit: {{ .Values.puppetserver.masters.backup.failedJobsHistoryLimit }}
+  schedule: "{{ .Values.puppetserver.masters.backup.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.puppetserver.masters.backup.successfulJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "puppetserver.puppetserver.labels" . | nindent 8 }}
+    spec:
+      template:
+        spec:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    {{- include "puppetserver.puppetserver.matchLabels" . | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+          restartPolicy: OnFailure
+          containers:
+          - name: restic-backup
+            image: "{{ .Values.puppetserver.masters.backup.image }}:{{ .Values.puppetserver.masters.backup.tag }}"
+            imagePullPolicy: {{ .Values.puppetserver.masters.backup.pullPolicy }}
+            command:
+            - /bin/sh
+            - -c
+            - |-
+              set -euf
+              restic snapshots -q || restic init -q
+              restic backup --tag=puppet-ca --host={{ .Values.puppetserver.name }} /backup
+              restic forget --prune --keep-last {{ .Values.puppetserver.masters.backup.restic.keep_last }}
+            resources:
+              {{- toYaml .Values.puppetserver.masters.backup.resources | nindent 14 }}
+            env:
+            - name: RESTIC_REPOSITORY
+              value: {{ .Values.puppetserver.masters.backup.restic.repository | quote }}
+            - name: RESTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: restic-backup-creds
+                  key: restic_password
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: restic-backup-creds
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: restic-backup-creds
+                  key: secret_access_key
+            volumeMounts:
+            - name: puppet-ca-storage
+              mountPath: /backup/etc/puppetlabs/puppetserver/ca/
+            - name: puppet-puppet-storage
+              mountPath: /backup/etc/puppetlabs/puppet/
+          volumes:
+          - name: puppet-ca-storage
+          {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.ca.enable }}
+            {{- toYaml .Values.puppetserver.masters.customPersistentVolumeClaim.ca.config | nindent 10 }}
+          {{- else }}
+            persistentVolumeClaim:
+              claimName: puppet-ca-claim
+          {{- end }}
+          - name: puppet-puppet-storage
+          {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.puppet.enable }}
+            {{- toYaml .Values.puppetserver.masters.customPersistentVolumeClaim.puppet.config | nindent 10 }}
+          {{- else }}
+            persistentVolumeClaim:
+              claimName: puppet-puppet-claim
+          {{- end }}
+{{- end }}

--- a/templates/puppetserver-ca-backup-secret.yaml
+++ b/templates/puppetserver-ca-backup-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.puppetserver.masters.backup.enabled (not .Values.singleCA.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: restic-backup-creds
+  labels:
+    {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- with .Values.puppetserver.masters.backup.restic }}
+  {{- if .password }}
+  restic_password: {{ .password | b64enc | quote }}
+  {{- end }}
+  {{- if .access_key_id }}
+  access_key_id: {{ .access_key_id | b64enc | quote }}
+  {{- end }}
+  {{- if .secret_access_key }}
+  secret_access_key: {{ .secret_access_key | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/templates/puppetserver-code-pvc.yaml
+++ b/templates/puppetserver-code-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if (not .Values.puppetserver.compilers.enabled) }}
 {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.code.enable }}
 {{- else }}
 apiVersion: v1
@@ -23,4 +24,5 @@ spec:
   storageClassName: "{{ .Values.storage.storageClass }}"
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/puppetserver-custom-entrypoints-configmap.yaml
+++ b/templates/puppetserver-custom-entrypoints-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.puppetserver.customentrypoints.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: puppetserver-customentrypoints
+  labels:
+    {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
+data:
+{{- toYaml .Values.puppetserver.customentrypoints.configmaps | nindent 2 }}
+{{- end }}
+

--- a/templates/puppetserver-customconfigs-configmap.yaml
+++ b/templates/puppetserver-customconfigs-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.puppetserver.customconfigs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: puppetserver-custom-configs
+  labels:
+    {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
+data:
+{{- toYaml .Values.puppetserver.customconfigs.configmaps | nindent 2 }}
+{{- end }}
+

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -28,6 +28,12 @@ spec:
         checksum/r10k-code.configmap: {{ include (print $.Template.BasePath "/r10k-code.configmap.yaml") . | sha256sum }}
         checksum/r10k-hiera.configmap: {{ include (print $.Template.BasePath "/r10k-hiera.configmap.yaml") . | sha256sum }}
         checksum/crl-config: {{ include (print $.Template.BasePath "/update-crl-configmap.yaml") . | sha256sum }}
+        {{- if .Values.puppetserver.customconfigs.enabled }}
+        checksum/custom-configs.configmap: {{ include (print $.Template.BasePath "/puppetserver-customconfigs-configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.puppetserver.customentrypoints.enabled }}
+        checksum/custom-entrypoints.configmap: {{ include (print $.Template.BasePath "/puppetserver-custom-entrypoints-configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
@@ -67,6 +73,7 @@ spec:
               mkdir -p /etc/puppetlabs/puppet/manifests;
               mkdir -p /etc/puppetlabs/code/r10k_cache;
               chown -R puppet:puppet /etc/puppetlabs;
+              {{- if (not .Values.puppetserver.compilers.enabled) }}
               {{- if .Values.puppetserver.puppeturl }}
               cp /etc/puppetlabs/puppet/configmap/r10k_code_entrypoint.sh /etc/puppetlabs/puppet/r10k_code_entrypoint.sh;
               cp /etc/puppetlabs/puppet/configmap/r10k_code_cronjob.sh /etc/puppetlabs/puppet/r10k_code_cronjob.sh;
@@ -93,6 +100,7 @@ spec:
               cp /etc/puppetlabs/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
               {{- end }}
+              {{- end }}
               {{- if .Values.singleCA.enabled }}
               cp /etc/puppetlabs/puppet/configmap/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh;
               cp /etc/puppetlabs/puppet/configmap/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh;
@@ -100,16 +108,18 @@ spec:
               chown puppet:puppet /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
               chmod +x /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
               {{- end }}
+              {{- if .Values.puppetserver.extraInitArgs }}
+              {{- .Values.puppetserver.extraInitArgs | nindent 14 }}
+              {{- end }}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
-            privileged: true
           volumeMounts:
-            - name: puppet-code-storage
-              mountPath: /etc/puppetlabs/code/
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
-            {{- if .Values.puppetserver.puppeturl }}
+            {{- if and .Values.puppetserver.puppeturl (not .Values.puppetserver.compilers.enabled) }}
+            - name: puppet-code-storage
+              mountPath: /etc/puppetlabs/code/
             - name: r10k-code-volume
               mountPath: /etc/puppetlabs/puppet/configmap/r10k_code_entrypoint.sh
               subPath: r10k_code_entrypoint.sh
@@ -119,7 +129,6 @@ spec:
             - name: r10k-code-volume
               mountPath: /etc/puppetlabs/puppet/configmap/r10k_code.yaml
               subPath: r10k_code.yaml
-            {{- end }}
             {{- if (include "hiera.enable" .) }}
             - name: r10k-hiera-volume
               mountPath: /etc/puppetlabs/puppet/configmap/r10k_hiera_entrypoint.sh
@@ -131,19 +140,11 @@ spec:
               mountPath: /etc/puppetlabs/puppet/configmap/r10k_hiera.yaml
               subPath: r10k_hiera.yaml
             {{- end }}
-            {{- if .Values.puppetserver.masters.multiMasters.enabled }}
-            - name: init-masters-volume
-              mountPath: /etc/puppetlabs/puppet/configmap/check_for_masters.sh
-              subPath: check_for_masters.sh
-            {{- end }}
             {{- if .Values.hiera.config }}
             - name: hiera-volume
               mountPath: /etc/puppetlabs/puppet/configmap/hiera.yaml
               subPath: hiera.yaml
             {{- end }}
-            - name: manifests-volume
-              mountPath: /etc/puppetlabs/puppet/configmap/site.pp
-              subPath: site.pp
             {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml
@@ -156,6 +157,15 @@ spec:
               mountPath: /etc/puppetlabs/puppet/configmap/eyaml/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
             {{- end }}
+            {{- end }}
+            {{- if .Values.puppetserver.masters.multiMasters.enabled }}
+            - name: init-masters-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/check_for_masters.sh
+              subPath: check_for_masters.sh
+            {{- end }}
+            - name: manifests-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/site.pp
+              subPath: site.pp
             {{- if .Values.singleCA.enabled }}
             - name: crl-volume
               mountPath: /etc/puppetlabs/puppet/configmap/crl_entrypoint.sh
@@ -218,15 +228,27 @@ spec:
           ports:
             - containerPort: {{ template "puppetserver.puppetserver-masters.port" .}}
           volumeMounts:
+            {{- if (not .Values.puppetserver.compilers.enabled) }}
             - name: puppet-code-storage
               mountPath: /etc/puppetlabs/code/
+            {{- end }}
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
             - name: puppet-ca-storage
               mountPath: /etc/puppetlabs/puppetserver/ca/
-        {{- if .Values.puppetserver.puppeturl }}
+            {{- range $key, $value := .Values.puppetserver.customconfigs.configmaps }}
+            - name: puppetserver-custom-configs
+              mountPath: /etc/puppetlabs/puppetserver/conf.d/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
+            {{- range $key, $value := .Values.puppetserver.customentrypoints.configmaps }}
+            - name: puppetserver-customentrypoints
+              mountPath: /docker-custom-entrypoint.d/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
+        {{- if and .Values.puppetserver.puppeturl (not .Values.puppetserver.compilers.enabled) }}
         # r10k Code Sidecar
         - name: r10k-code
           image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
@@ -269,7 +291,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         {{- end }}
-        {{- if (include "hiera.enable" .) }}
+        {{- if and (include "hiera.enable" .) (not .Values.puppetserver.compilers.enabled) }}
         # r10k Hiera Sidecar
         - name: r10k-hiera
           image: "{{.Values.r10k.image}}:{{.Values.r10k.tag}}"
@@ -370,12 +392,14 @@ spec:
       securityContext:
         fsGroup: 999   # "puppet" GID
       volumes:
+        {{- if (not .Values.puppetserver.compilers.enabled) }}
         - name: puppet-code-storage
         {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.code.enable }}
           {{- toYaml .Values.puppetserver.masters.customPersistentVolumeClaim.code.config | nindent 10 }}
         {{- else }}
           persistentVolumeClaim:
             claimName: puppet-code-claim
+        {{- end }}
         {{- end }}
         - name: puppet-ca-storage
         {{- if .Values.puppetserver.masters.customPersistentVolumeClaim.ca.enable }}
@@ -408,14 +432,26 @@ spec:
           configMap:
             name: init-masters-config
         {{- end }}
+        {{- if .Values.puppetserver.customconfigs.enabled }}
+        - name: puppetserver-custom-configs
+          configMap:
+            name: puppetserver-custom-configs
+        {{- end }}
+        {{- if .Values.puppetserver.customentrypoints.enabled }}
+        - name: puppetserver-customentrypoints
+          configMap:
+            name: puppetserver-customentrypoints
+            defaultMode: 0777
+        {{- end }}
+        - name: manifests-volume
+          configMap:
+            name: manifests-config
+        {{- if (not .Values.puppetserver.compilers.enabled) }}
         {{- if .Values.hiera.config }}
         - name: hiera-volume
           configMap:
             name: hiera-config
         {{- end }}
-        - name: manifests-volume
-          configMap:
-            name: manifests-config
         {{- if .Values.hiera.eyaml.existingSecret }}
         - name: eyaml-volume
           secret:
@@ -481,6 +517,12 @@ spec:
             items:
               - key: netrc
                 path: .netrc
+        {{- end }}
+        {{- end }}
+        {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
+        - name: {{ $extraSecret.name }}
+          secret:
+            secretName: {{ $extraSecret.name }}
         {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/templates/puppetserver-service-masters.yaml
+++ b/templates/puppetserver-service-masters.yaml
@@ -19,7 +19,4 @@ spec:
     {{- end }}
   selector:
     {{- include "puppetserver.puppetserver.matchLabels" . | nindent 4 }}
-  type: {{ .Values.puppetserver.masters.service.type }}
-  {{- if (and (eq .Values.puppetserver.masters.service.type "LoadBalancer") (not (empty .Values.puppetserver.masters.service.loadBalancerIP))) }}
-  loadBalancerIP: {{ .Values.puppetserver.masters.service.loadBalancerIP }}
-  {{- end }}
+  type: ClusterIP

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -33,6 +33,12 @@ spec:
         checksum/r10k-code.configmap: {{ include (print $.Template.BasePath "/r10k-code.configmap.yaml") . | sha256sum }}
         checksum/r10k-hiera.configmap: {{ include (print $.Template.BasePath "/r10k-hiera.configmap.yaml") . | sha256sum }}
         checksum/crl-config: {{ include (print $.Template.BasePath "/update-crl-configmap.yaml") . | sha256sum }}
+        {{- if .Values.puppetserver.customconfigs.enabled }}
+        checksum/custom-configs.configmap: {{ include (print $.Template.BasePath "/puppetserver-customconfigs-configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.puppetserver.customentrypoints.enabled }}
+        checksum/custom-entrypoints.configmap: {{ include (print $.Template.BasePath "/puppetserver-custom-entrypoints-configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
@@ -51,6 +57,11 @@ spec:
             limits:
               memory: 256Mi
               cpu: 300m
+          env:
+            {{- range $key, $value := .Values.puppetserver.compilers.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /etc/puppetlabs/puppet/eyaml/keys;
@@ -96,10 +107,12 @@ spec:
               chown puppet:puppet /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
               chmod +x /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl.sh;
               {{- end }}
+              {{- if .Values.puppetserver.extraInitArgs }}
+              {{- .Values.puppetserver.extraInitArgs | nindent 14 }}
+              {{- end }}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
-            privileged: true
           volumeMounts:
             - name: puppet-code-volume
               mountPath: /etc/puppetlabs/code/
@@ -214,6 +227,16 @@ spec:
               mountPath: /etc/puppetlabs/code/
             - name: puppet-puppet-volume
               mountPath: /etc/puppetlabs/puppet/
+            {{- range $key, $value := .Values.puppetserver.customconfigs.configmaps }}
+            - name: puppetserver-custom-configs
+              mountPath: /etc/puppetlabs/puppetserver/conf.d/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
+            {{- range $key, $value := .Values.puppetserver.customentrypoints.configmaps }}
+            - name: puppetserver-customentrypoints
+              mountPath: /docker-custom-entrypoint.d/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
         {{- if .Values.puppetserver.puppeturl }}
         # r10k Code Sidecar
         - name: r10k-code
@@ -362,6 +385,17 @@ spec:
         - name: hiera-volume
           configMap:
             name: hiera-config
+        {{- end }}
+        {{- if .Values.puppetserver.customconfigs.enabled }}
+        - name: puppetserver-custom-configs
+          configMap:
+            name: puppetserver-custom-configs
+        {{- end }}
+        {{- if .Values.puppetserver.customentrypoints.enabled }}
+        - name: puppetserver-customentrypoints
+          configMap:
+            name: puppetserver-customentrypoints
+            defaultMode: 0777
         {{- end }}
         {{- if .Values.singleCA.enabled }}
         - name: crl-volume

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -10,13 +10,14 @@ data:
     # The location to use for storing cached Git repos
     :cachedir: '/etc/puppetlabs/code/r10k_cache'
     # A list of git repositories to create
+    {{- toYaml .Values.r10k.code.extraSettings | nindent 4 }}
     :sources:
       # This will clone the git repository and instantiate an environment per
       # branch in '/etc/puppetlabs/code/environments'
       :puppet_repo:
         remote: '{{.Values.puppetserver.puppeturl}}'
-        basedir: '/etc/puppetlabs/code/environments'
-    {{ .Values.r10k.code.extraSettings | nindent 4 }}
+        basedir: '{{.Values.puppetserver.puppetbasedir}}'
+    {{- toYaml .Values.r10k.code.extraRepos | nindent 6 }}
 
   r10k_code_cronjob.sh: |
     #!/usr/bin/env sh

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -9,6 +9,7 @@ data:
   r10k_hiera.yaml: |
     # The location to use for storing cached Git repos
     :cachedir: '/etc/puppetlabs/code/r10k_cache'
+    {{- toYaml .Values.r10k.hiera.extraSettings | nindent 4 }}
     # A list of git repositories to create
     :sources:
       {{- if .Values.hiera.hieradataurl }}
@@ -17,11 +18,8 @@ data:
       :hiera_repo:
         remote: '{{.Values.hiera.hieradataurl}}'
         basedir: '/etc/puppetlabs/code/hiera-data'
+    {{- toYaml .Values.r10k.hiera.extraRepos | nindent 6 }}
       {{- end }}
-      {{- with .Values.r10k.hiera.extraRepository }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-    {{ .Values.r10k.hiera.extraSettings | indent 4 }}
 
   r10k_hiera_cronjob.sh: |
     #!/usr/bin/env sh

--- a/values.yaml
+++ b/values.yaml
@@ -155,6 +155,33 @@ puppetserver:
         enable: false
         config: {}
 
+    ## enable if a kubernetes CronJob should be backup the puppetserver master pv's
+    #
+    backup:
+      enabled: false
+      resources: {}
+      #  requests:
+      #    memory: 256Mi
+      #    cpu: 750m
+      #  limits:
+      #    memory: 512Mi
+      #    cpu: 1000m
+
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 2
+
+      schedule: "@every 12h"
+      image: restic/restic
+      tag: 0.13.1
+      pullPolicy: IfNotPresent
+
+      restic:
+        keep_last: 90 # days
+        repository: "" # "s3:https://s3.minio.xx/backups/"
+        access_key_id: "" # s3 access key
+        secret_access_key: "" # s3 secret access key
+        password: "" # restic encryption password
+
   ## Optional StatefulSet of Puppet Server Compiler/s
   ##
   compilers:

--- a/values.yaml
+++ b/values.yaml
@@ -37,9 +37,9 @@ puppetserver:
 
     updateStrategy:
       type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 20%
-        maxUnavailable: 0%
+    # rollingUpdate:
+    #   maxSurge: 20%
+    #   maxUnavailable: 0%
 
     ## Puppet Server Master readiness and liveness probe initial delays and timeouts
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -300,6 +300,31 @@ puppetserver:
     enabled: false
     jobDeadline: 300
 
+  ## Custom puppetserver conf.d configs
+  ##
+  customconfigs:
+    enabled: false
+    configmaps: {}
+    #  auth.conf: |-
+    #    {}
+
+  ## Custom puppetserver entrypoints
+  ##
+  customentrypoints:
+    enabled: false
+    configmaps: {}
+    #  entry1.sh: |-
+    #    #!/bin/sh
+    #    echo hi
+
+  ## Optional Secrets to mount in puppetserver container
+  ##
+  extraSecrets: []
+
+  ## Optional init arguments
+  extraInitArgs: |-
+    ""
+
   ## Optional configure serviceAccount & rbac
   serviceAccount:
     enabled: false
@@ -318,6 +343,7 @@ puppetserver:
   ## A separate Hieradata Repo can be included in the "hiera" section in this file.
   ##
   puppeturl: ""   #  git@github.com:$SOMEUSER/puppet.git
+  puppetbasedir: /etc/puppetlabs/code/environments
 
 ## r10k Repo Configuration
 ##
@@ -348,7 +374,9 @@ r10k:
     #   - --color
     ## Additional r10k code container environment variables
     extraEnv: {}
-    extraSettings: ""
+    extraSettings: {}
+    extraRepos: {}
+
     viaHttps:
       credentials:
         netrc:
@@ -395,7 +423,8 @@ r10k:
     #   - --color
     ## Additional puppetserver hiera container environment variables
     extraEnv: {}
-    extraSettings: ""
+    extraSettings: {}
+    extraRepos: {}
     viaHttps:
       credentials:
         netrc:
@@ -424,6 +453,7 @@ r10k:
 ## PuppetDB Configuration
 ##
 puppetdb:
+  enabled: true
   name: puppetdb
   image: puppet/puppetdb
   tag: 7.7.1


### PR DESCRIPTION
- feat: optional deployment of the puppetdb component (default true)
- feat: remove privileged from securityContext (I do not understand why it was used/needed??)
- feat: inject custom entrypoints which will be exuected during puppetserver startup
- feat: inject custom configmaps to configure puppetserver itself (configmaps mounted in /etc/puppetlabs/puppetserver/conf.d)
- feat: support extra r10k hiera & code repositories
- feat: add a restic backup Cronjob to backup our puppetserver master pv's
- fix: use r10k code & hiera extrasettings as map (global r10k configuration can be injected this way)
- fix: puppet service configured as ClusterIP only.
- fix: if compilers are deployed remove r10k container & code volumes from masters