### PR TITLE
r10k add -t to timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.5.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.1) (2022-08-17)
+
+- fix: add -t flag to timeout for r10k:3.14.0 and below
+
 ## [v6.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.0) (2022-07-29)
 
 - feat: optional deployment of the puppetdb component (default true)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.5.0
+version: 6.5.1
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -436,3 +436,4 @@ kill %[job_numbers_above]
 * [Aidan](https://github.com/artificial-aidan), Contributor
 * [Aurélien Le Clainche](https://www.linkedin.com/in/aurelien-le-clainche/), Contributor
 * [Simon Fuhrer](https://github.com/simonfuhrer), Contributor
+* [Kevin Harrington](https://github.com/ke5C2Fin), Contributor

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -24,7 +24,7 @@ data:
     {{- if .Values.r10k.code.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.code.cronJob.splayLimit }} ))
     {{- end }}
-    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
+    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 -t {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
     --puppetfile {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -26,7 +26,7 @@ data:
     {{- if .Values.r10k.hiera.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.hiera.cronJob.splayLimit }} ))
     {{- end }}
-    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
+    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 -t {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
     --puppetfile {{ template "r10k.hiera.args" . }} > ~/.r10k_hiera_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then


### PR DESCRIPTION
Add -t flag to timeout in r10k, only valid for r10k:3.14.0 and below.
```
r10k-code $ timeout
BusyBox v1.29.3 (2019-01-24 07:45:07 UTC) multi-call binary.

Usage: timeout [-t SECS] [-s SIG] PROG ARGS

Runs PROG. Sends SIG to it if it is not gone in SECS seconds.
Defaults: SECS: 10, SIG: TERM.
```