### PR TITLE
Prevent errors when not specifying extraInitArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.2) (2022-08-18)
+
+- fix: Prevent errors when not specifying extraInitArgs
+
 ## [v6.5.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.1) (2022-08-17)
 
 - fix: add -t flag to timeout for r10k:3.14.0 and below

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.5.1
+version: 6.5.2
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/values.yaml
+++ b/values.yaml
@@ -349,8 +349,7 @@ puppetserver:
   extraSecrets: []
 
   ## Optional init arguments
-  extraInitArgs: |-
-    ""
+  extraInitArgs: ""
 
   ## Optional configure serviceAccount & rbac
   serviceAccount:


### PR DESCRIPTION
The string `""` previously showed up verbatim in the generated shell script.
Since this is not a valid shell command, sh throws an error:
```
sh: 1: : Permission denied
```
Not sure what sh is trying to get permission for there, but you can reproduce this with the following command:
```
$ sh -c '""'
sh: 1: : Permission denied
```
After this change, it just becomes an empty string and no longer causes any issues.

Workaround: override the value to an empty string via --set or --values