### PR TITLE
Prevent errors when not specifying r10k.code.extraSettings or r10k.code.extraRepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.5.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.2) (2022-08-18)
+
+- fix: Prevent errors when not specifying r10k.code.extraSettings or r10k.code.extraRepos
+
 ## [v6.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.2) (2022-08-18)
 
 - fix: Prevent errors when not specifying extraInitArgs

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.5.2
+version: 6.5.3
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -10,14 +10,18 @@ data:
     # The location to use for storing cached Git repos
     :cachedir: '/etc/puppetlabs/code/r10k_cache'
     # A list of git repositories to create
+    {{- if .Values.r10k.code.extraSettings }}
     {{- toYaml .Values.r10k.code.extraSettings | nindent 4 }}
+    {{- end }}
     :sources:
       # This will clone the git repository and instantiate an environment per
       # branch in '/etc/puppetlabs/code/environments'
       :puppet_repo:
         remote: '{{.Values.puppetserver.puppeturl}}'
         basedir: '{{.Values.puppetserver.puppetbasedir}}'
+    {{- if .Values.r10k.code.extraRepos }}
     {{- toYaml .Values.r10k.code.extraRepos | nindent 6 }}
+    {{- end }}
 
   r10k_code_cronjob.sh: |
     #!/usr/bin/env sh


### PR DESCRIPTION
Similar deal as #128:
It works fine as long as you actually use those settings, but if you don't, `toYaml` will generate `{}`, invalidating the YAML and causing errors in the r10k-code container:
```
r10k: Runtime error: #<R10K::Settings::Loader::ConfigError: Couldn't load config file: (/etc/puppetlabs/puppet/r10k_code.yaml): could not find expected ':' while scanning a simple key at line 4 column 1>
```

Note: Due to the sub-chart, I have no way of testing this, so this PR is entirely untested.
Would be cool if you could describe in the README how to test this locally.

Workaround:
```yaml
r10k:
  code:
    extraRepos:
      :nope: null
    extraSettings:
      :nope: null
```
The workaround is not perfect, but apparently it passes readiness now