### PR TITLE
Allow to change load balancer type for puppet master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v6.5.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.2) (2022-08-18)
+## [v6.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.6.0) (2022-10-04)
+
+- feat: Allow to change load balancer type for puppet master if compilers are not used
+
+## [v6.5.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.3) (2022-08-19)
 
 - fix: Prevent errors when not specifying r10k.code.extraSettings or r10k.code.extraRepos
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.5.3
+version: 6.6.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -437,3 +437,4 @@ kill %[job_numbers_above]
 * [Aurélien Le Clainche](https://www.linkedin.com/in/aurelien-le-clainche/), Contributor
 * [Simon Fuhrer](https://github.com/simonfuhrer), Contributor
 * [Kevin Harrington](https://github.com/ke5C2Fin), Contributor
+* [Grégoire Menuel](https://github.com/gmenuel), Contributor

--- a/templates/puppetserver-service-masters.yaml
+++ b/templates/puppetserver-service-masters.yaml
@@ -19,4 +19,11 @@ spec:
     {{- end }}
   selector:
     {{- include "puppetserver.puppetserver.matchLabels" . | nindent 4 }}
+{{- if .Values.puppetserver.compilers.enabled }}
   type: ClusterIP
+{{- else }}
+  type: {{ .Values.puppetserver.masters.service.type }}
+  {{- if (and (eq .Values.puppetserver.masters.service.type "LoadBalancer") (not (empty .Values.puppetserver.masters.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.puppetserver.masters.service.loadBalancerIP }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
If compilers are not used the LoadBalancer type of the puppet master service was fixed to ClusterIP. This PR change this behaviour and re-allow to change the LoadBalancer type.

Closes: #132