### PR TITLE
have r10k-hiera extraSettings and extraRepos act like r10k-code and n…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.7.0) (2022-10-17)
+
+- fix: have r10k-hiera extraSettings and extraRepos act like r10k-code and not print empty {} in r10k_hiera.yaml
+- feat: add .Values.r10k.defaultRepoExtraConf to pass in yaml config for r10k-code and r10k-hiera config
+
 ## [v6.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.6.0) (2022-10-04)
 
 - feat: Allow to change load balancer type for puppet master if compilers are not used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 ## [v6.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.7.0) (2022-10-17)
 
 - fix: have r10k-hiera extraSettings and extraRepos act like r10k-code and not print empty {} in r10k_hiera.yaml
-- feat: add .Values.r10k.defaultRepoExtraConf to pass in yaml config for r10k-code and r10k-hiera config
+- feat: add .Values.r10k.hiera.defaultRepoExtraConf and .Values.r10k.code.defaultRepoExtraConf to pass in yaml config for r10k_code.yaml and r10k_hiera.yaml configs
 
 ## [v6.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.6.0) (2022-10-04)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.6.0
+version: 6.7.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.code.cronJob.splayLimit` | maximum splay in seconds applied before running r10k control repo cron job | `60`|
 | `r10k.code.cronJob.timeout` | timeout in seconds to apply when running r10k control repo cron job takes too long | ``|
 | `r10k.code.cronJob.successFile` | path to file reflecting success of r10k control repo cron job | `~/.r10k_code_cronjob.success`|
+| `r10k.code.defaultRepoExtraConf` | yaml to be added to the default repo in r10k_code.yaml |``|
 | `r10k.code.extraArgs` | r10k control repo additional container env args |``|
 | `r10k.code.extraEnv` | r10k control repo additional container env vars |``|
 | `r10k.code.viaSsh.credentials.ssh.value`| r10k control repo ssh key file |``|
@@ -276,6 +277,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.hiera.cronJob.splayLimit` | maximum splay in seconds applied before running r10k hiera data cron job | `60`|
 | `r10k.hiera.cronJob.timeout` | timeout in seconds to apply when running r10k hiera data cron job takes too long | ``|
 | `r10k.hiera.cronJob.successFile` | path to file reflecting success of r10k hiera data cron job | `~/.r10k_hiera_cronjob.success`|
+| `r10k.hiera.defaultRepoExtraConf` | yaml to be added to the default repo in r10k_hiera.yaml |``|
 | `r10k.hiera.extraArgs` | r10k hiera data additional container env args |``|
 | `r10k.hiera.extraEnv` | r10k hiera data additional container env vars |``|
 | `r10k.hiera.viaSsh.credentials.ssh.value`| r10k hiera data ssh key file |``|

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -17,8 +17,11 @@ data:
       # This will clone the git repository and instantiate an environment per
       # branch in '/etc/puppetlabs/code/environments'
       :puppet_repo:
-        remote: '{{.Values.puppetserver.puppeturl}}'
-        basedir: '{{.Values.puppetserver.puppetbasedir}}'
+        remote: '{{ .Values.puppetserver.puppeturl }}'
+        basedir: '{{ .Values.puppetserver.puppetbasedir }}'
+        {{- if .Values.r10k.defaultRepoExtraConf }}
+        {{- toYaml .Values.r10k.defaultRepoExtraConf | nindent 8 }}
+        {{- end }}
     {{- if .Values.r10k.code.extraRepos }}
     {{- toYaml .Values.r10k.code.extraRepos | nindent 6 }}
     {{- end }}

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -19,8 +19,8 @@ data:
       :puppet_repo:
         remote: '{{ .Values.puppetserver.puppeturl }}'
         basedir: '{{ .Values.puppetserver.puppetbasedir }}'
-        {{- if .Values.r10k.defaultRepoExtraConf }}
-        {{- toYaml .Values.r10k.defaultRepoExtraConf | nindent 8 }}
+        {{- if .Values.r10k.code.defaultRepoExtraConf }}
+        {{- toYaml .Values.r10k.code.defaultRepoExtraConf | nindent 8 }}
         {{- end }}
     {{- if .Values.r10k.code.extraRepos }}
     {{- toYaml .Values.r10k.code.extraRepos | nindent 6 }}

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -9,16 +9,23 @@ data:
   r10k_hiera.yaml: |
     # The location to use for storing cached Git repos
     :cachedir: '/etc/puppetlabs/code/r10k_cache'
+    {{- if .Values.r10k.hiera.extraSettings }}
     {{- toYaml .Values.r10k.hiera.extraSettings | nindent 4 }}
+    {{- end }}
     # A list of git repositories to create
     :sources:
       {{- if .Values.hiera.hieradataurl }}
       # This will clone the git repository and instantiate an environment per
       # branch in '/etc/puppetlabs/code/hiera-data'
       :hiera_repo:
-        remote: '{{.Values.hiera.hieradataurl}}'
+        remote: '{{ .Values.hiera.hieradataurl }}'
         basedir: '/etc/puppetlabs/code/hiera-data'
-    {{- toYaml .Values.r10k.hiera.extraRepos | nindent 6 }}
+        {{- if .Values.r10k.defaultRepoExtraConf }}
+        {{- toYaml .Values.r10k.defaultRepoExtraConf | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.r10k.hiera.extraRepos }}
+      {{- toYaml .Values.r10k.hiera.extraRepos | nindent 6 }}
       {{- end }}
 
   r10k_hiera_cronjob.sh: |

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -20,8 +20,8 @@ data:
       :hiera_repo:
         remote: '{{ .Values.hiera.hieradataurl }}'
         basedir: '/etc/puppetlabs/code/hiera-data'
-        {{- if .Values.r10k.defaultRepoExtraConf }}
-        {{- toYaml .Values.r10k.defaultRepoExtraConf | nindent 8 }}
+        {{- if .Values.r10k.hiera.defaultRepoExtraConf }}
+        {{- toYaml .Values.r10k.hiera.defaultRepoExtraConf | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.r10k.hiera.extraRepos }}

--- a/values.yaml
+++ b/values.yaml
@@ -378,7 +378,6 @@ r10k:
   image: puppet/r10k
   tag: 3.13.0
   pullPolicy: IfNotPresent
-  defaultRepoExtraConf: {}
   code:
     resources: {}
     #  requests:
@@ -403,7 +402,7 @@ r10k:
     extraEnv: {}
     extraSettings: {}
     extraRepos: {}
-
+    defaultRepoExtraConf: {}
     viaHttps:
       credentials:
         netrc:
@@ -452,6 +451,7 @@ r10k:
     extraEnv: {}
     extraSettings: {}
     extraRepos: {}
+    defaultRepoExtraConf: {}
     viaHttps:
       credentials:
         netrc:

--- a/values.yaml
+++ b/values.yaml
@@ -378,6 +378,7 @@ r10k:
   image: puppet/r10k
   tag: 3.13.0
   pullPolicy: IfNotPresent
+  defaultRepoExtraConf: {}
   code:
     resources: {}
     #  requests:


### PR DESCRIPTION
have r10k-hiera extraSettings and extraRepos act like r10k-code and not print empty {} in r10k_hiera.yaml
fixed some misc formatting in the templates
add .Values.r10k.defaultRepoExtraConf to pass in yaml config for r10k-code and r10k-hiera config
ie to provide in values
```
r10k:
  defaultRepoExtraConf:
    ignore_branch_prefixes:
    - prod_
```
To get this in the r10k_hiera.yaml and r10k_code.yaml
```
:sources:
  :hiera_repo:
    ...
    ignore_branch_prefixes:
    - prod_
```
This could also be changed to something like r10k.code.defaultRepoExtraConf and r10k.hiera.defaultRepoExtraConf if it is more typical of a usecase to change specific settings in each. My use case has them both being changed the same way.