### PR TITLE
Attempting to fix `extraLabels` utilization

### DIFF
--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "puppetserver.name" . }}-puppetdb
   labels:
     {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
-    {{- with .Values.puppetdb.extraLabels }}
-    {{ toYaml . | indent 6 }}
+    {{- with .Values.puppetdb.extraLabels -}}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
@@ -19,6 +19,9 @@ spec:
     metadata:
       labels:
         {{- include "puppetserver.puppetdb.labels" . | nindent 8 }}
+        {{- with .Values.puppetdb.extraLabels -}}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "puppetserver.name" . }}-puppetserver-master-backup
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-    {{- with .Values.puppetserver.masters.extraLabels }}
-    {{ toYaml . | indent 6 }}
+    {{- with .Values.puppetserver.masters.extraLabels -}}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
   concurrencyPolicy: Forbid

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ template "puppetserver.name" . }}-puppetserver-master
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-    {{- with .Values.puppetserver.masters.extraLabels }}
-    {{ toYaml . | indent 6 }}
+    {{- with .Values.puppetserver.masters.extraLabels -}}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.puppetserver.masters.multiMasters.enabled }}
@@ -23,6 +23,9 @@ spec:
     metadata:
       labels:
         {{- include "puppetserver.puppetserver.labels" . | nindent 8 }}
+        {{- with .Values.puppetserver.masters.extraLabels -}}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/hiera-configmap: {{ include (print $.Template.BasePath "/hiera-configmap.yaml") . | sha256sum }}
         checksum/r10k-code.configmap: {{ include (print $.Template.BasePath "/r10k-code.configmap.yaml") . | sha256sum }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "puppetserver.name" . }}-puppetserver-compiler
   labels:
     {{- include "puppetserver.puppetserver-compilers.labels" . | nindent 4 }}
-    {{- with .Values.puppetserver.compilers.extraLabels }}
-    {{ toYaml . | indent 6 }}
+    {{- with .Values.puppetserver.compilers.extraLabels -}}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.puppetserver.compilers.annotations }}
   annotations:
@@ -28,6 +28,9 @@ spec:
     metadata:
       labels:
         {{- include "puppetserver.puppetserver-compilers.labels" . | nindent 8 }}
+        {{- with .Values.puppetserver.compilers.extraLabels -}}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/hiera-configmap: {{ include (print $.Template.BasePath "/hiera-configmap.yaml") . | sha256sum }}
         checksum/r10k-code.configmap: {{ include (print $.Template.BasePath "/r10k-code.configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
Per https://github.com/puppetlabs/puppetserver-helm-chart/issues/135, this is an attempt at getting `extraLabels` working as expected.  Using this change locally results in my expected behavior.

## Expected Behavior
I would expect that I can populate `extraLabels` as a map like:
```
puppetserver:
  ...
  masters:
    ...
    extraLabels:
      keyA: valueA
      keyB: valueB
```

and have the labels appended to the generated labels section:
```
kind: Deployment
metadata:
  name: puppetserver-puppetserver-master
  labels:
    app.kubernetes.io/component: puppetserver
    app.kubernetes.io/name: puppetserver
    ...
    keyA: valueA
    keyB: valueB
```