### PR TITLE
fix multi masters/compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.8.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.1) (2022-12-07)
+
+- fix: change order of scripts in master init or it will error out if compliers are enabled
+- fix: add PUPPET_SSL_DIR env var and change check_for_masters.sh or init would wait indefinitely for ssl generation when running multi master
+- fix: change from deprecated autoscaling/v2beta2 HorizontalPodAutoscaler to autoscaling/v2
+
 ## [v6.8.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.0) (2022-10-26)
 
 - fix: Save crl to defined filename

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.8.0
+version: 6.8.1
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: PUPPET_DATA_DIR
               value: "/etc/puppetlabs/code/environments"
+            - name: PUPPET_SSL_DIR
+              value: "/etc/puppetlabs/puppet/ssl/certs"
             - name: PUPPET_SSL_CERT_PEM
               value: "/etc/puppetlabs/puppet/ssl/certs/{{ (include "puppetserver.puppetserver-masters.serviceName" . ) }}.pem"
           {{- end }}
@@ -92,8 +94,6 @@ spec:
               cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
               chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
               {{- end }}
-              cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
-              chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
               {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*private_key.pkcs7.pem;
@@ -101,6 +101,8 @@ spec:
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
               {{- end }}
               {{- end }}
+              cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
+              chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
               {{- if .Values.singleCA.enabled }}
               cp /etc/puppetlabs/puppet/configmap/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh;
               cp /etc/puppetlabs/puppet/configmap/crl_cronjob.sh /etc/puppetlabs/puppet/ssl/crl_cronjob.sh;

--- a/templates/puppetserver-hpa-compilers.yaml
+++ b/templates/puppetserver-hpa-compilers.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.puppetserver.compilers.enabled }}
 {{- if .Values.puppetserver.compilers.autoScaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "puppetserver.name" . }}-compilers-autoscaler

--- a/templates/puppetserver-hpa-masters.yaml
+++ b/templates/puppetserver-hpa-masters.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.puppetserver.masters.multiMasters.enabled }}
 {{- if .Values.puppetserver.masters.multiMasters.autoScaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "puppetserver.name" . }}-masters-autoscaler

--- a/templates/puppetserver-init-configmap.yaml
+++ b/templates/puppetserver-init-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   check_for_masters.sh: |
     #!/usr/bin/env bash
-    if [[ -d "$PUPPET_DATA_DIR" ]]; then
+    if [[ -d "$PUPPET_SSL_DIR" ]]; then
         echo "A Puppetserver master has already started running."
         echo "Waiting to finish the generation of the Puppet SSL certs..."
         sleep 5


### PR DESCRIPTION
I've had issues running multi masters and compilers (last working was 6.4.0 - yes i haven't updated in quite a while)

Changing the order of scripts in master init makes multi compilers work

If running multi masters, then the check_for_masters.sh script would check for the existence of a folder that's already there in the image. Changed that so it looks for a folder that gets created post cert request instead

Changed HorizontalPodAutoscaler to autoscaling/v2