### PR TITLE
Set postgresql.fullnameOverride to match chart name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.8.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.2) (2022-12-31)
+
+- fix: set postgresql.fullnameOverride to match chart name, avoids error when release name is different
+
 ## [v6.8.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.1) (2022-12-07)
 
 - fix: change order of scripts in master init or it will error out if compliers are enabled

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.8.1
+version: 6.8.2
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/values.yaml
+++ b/values.yaml
@@ -545,6 +545,9 @@ puppetdb:
 postgresql:
   enabled: true
   name: postgresql
+  ## Set fullnameOverride to match this chart's name
+  ##
+  fullnameOverride: puppetserver-postgresql
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
Postgresql's service name should match PUPPETDB_POSTGRES_HOSTNAME. Using the chart defaults, this only happens when the Helm release name is identical to the chart name (puppetserver).
Setting postgresql.fullnameOverride to puppetserver-postgresql allows the user to use different Helm release names. See #141