### PR TITLE
Bump version (major upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v7.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.0.0) (2023-01-05)
+
+- fix: autoscaling apiVersion, `autoscaling/v2` is available since 1.23
+- fix: postgresql dependency (upgrade to the lastest available chart `12.1.6`)
+- feat: add 2 init container on puppetdb deployment to start only when postgresql & puppet master is ready
+- feat: allow custom config on puppetdb
+- feat: bump Puppetserver to `v7.9.2`.
+- feat: bump PuppetDB to `v7.10.0`.
+- feat: bump Puppetboard to `v4.2.4`.
+- fix: move configmap in /tmp to avoid Read Only error in puppetserver init container
+
 ## [v6.8.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.2) (2022-12-31)
 
 - fix: set postgresql.fullnameOverride to match chart name, avoids error when release name is different

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: puppetserver
-version: 6.8.2
-appVersion: 7.4.2
+version: 7.0.0
+appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/
 icon: https://secure.gravatar.com/avatar/fdd009b7c1ec96e088b389f773e87aec.jpg?s=80&r=g&d=mm
 dependencies:
 - name: postgresql
-  version: 10.16.*
+  version: 12.1.6
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 sources:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ To achieve better throughput of Puppet Infrastructure, you can enable and scale 
 
 ### Multiple PostgreSQL Read Replicas
 
-To achieve better throughput of Puppet Infrastructure, you can enable and scale out PostgreSQL cluster using `.Values.postgresql.replication.enabled` and `.Values.postgresql.replication.slaveReplicas`.
+For now it's not available anymore, since bitnami cleanned their old release. for multiple Postgresql we have to use postgresql-ha.  
+Read replica return an error on puppetdb:  
+`ERROR [p.p.c.services] Will retry database connection after temporary failure: java.sql.SQLTransientConnectionException: PDBMigrationsPool: default - Connection is not available, request timed out after 3002ms.`
+
 
 ## Chart Components
 
@@ -145,6 +148,17 @@ The following table lists the configurable parameters of the Puppetserver chart 
 
 | Parameter | Description | Default|
 | --------- | ----------- | -------|
+| `global.curl.image`| curl image |`curlimages/curl`|
+| `global.curl.tag`| curl image tag |`7.87.0`|
+| `global.curl.imagePullPolicy`| curl image pull policy |`IfNotPresent`|
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | [] |
+| `global.pgchecker.image`| pgchecker image |`docker.io/busybox`|
+| `global.pgchecker.tag`| pgchecker image tag |`1.36`|
+| `global.pgchecker.imagePullPolicy`| pgchecker image pull policy |`IfNotPresent`|
+| `global.postgresql.auth.username`| puppetdb and postgresql username |`puppetdb`|
+| `global.postgresql.auth.password`| puppetdb and postgresql password |`unbreakablePassword`|
+| `global.postgresql.auth.existingSecret`| existing k8s secret that holds puppetdb and postgresql username and password |``|
+| `global.postgresql.*`| please refer to https://github.com/bitnami/charts/tree/main/bitnami/postgresql#global-parameters |``|
 | `puppetserver.name` | puppetserver component label | `puppetserver`|
 | `puppetserver.image` | puppetserver image | `puppet/puppetserver`|
 | `puppetserver.tag` | puppetserver img tag | `6.12.1`|
@@ -283,18 +297,12 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.hiera.viaSsh.credentials.ssh.value`| r10k hiera data ssh key file |``|
 | `r10k.hiera.viaSsh.credentials.known_hosts.value`| r10k hiera data ssh known hosts file |``|
 | `r10k.hiera.viaSsh.credentials.existingSecret`| r10k hiera data ssh secret that holds ssh key and known hosts files |``|
-| `postgresql.enabled` | postgres deployment as puppetdb backend | `true`|
-| `postgresql.name` | postgres component label | `postgresql`|
-| `postgresql.resources` | postgres resource limits |``|
-| `postgresql.postgresqlDatabase` | postgres database name |`puppetdb`|
-| `postgresql.initdbUser` | postgres username to run initdb scripts at first boot |`postgres`|
-| `postgresql.initdbScriptsConfigMap` | postgres initdb scripts run at first boot |`postgresql-custom-extensions`|
-| `postgresql.persistence.enabled` | postgres database persistence |`true`|
-| `postgresql.persistence.existingClaim` | postgres manually managed pvc |``|
-| `postgresql.persistence.size` | postgres persistence pvc size |`10Gi`|
-| `postgresql.persistence.annotations` | postgres persistence resource policy via annotations |`keep`|
-| `postgresql.replication.enabled` | postgres replication availability |`false`|
-| `postgresql.replication.slaveReplicas` | postgres replication slave replicas |`1`|
+| `postgresql.*`| please refer to https://github.com/bitnami/charts/tree/main/bitnami/postgresql#parameters |``|
+| `postgresql.primary.initdb.scriptsConfigMap` | postgres initdb scripts run at first boot |`postgresql-custom-extensions`|
+| `postgresql.primary.persistence.enabled` | postgres database persistence |`true`|
+| `postgresql.primary.persistence.existingClaim` | postgres manually managed pvc |``|
+| `postgresql.primary.persistence.size` | postgres persistence pvc size |`10Gi`|
+| `postgresql.primary.persistence.annotations` | postgres annotations for the PVC |`helm.sh/resource-policy: keep`|
 | `puppetdb.enabled` | puppetdb component enabled |`true`|
 | `puppetdb.name` | puppetdb component label | `puppetdb`|
 | `puppetdb.image` | puppetdb img | `puppet/puppetdb`|
@@ -313,7 +321,10 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetdb.customPersistentVolumeClaim.storage.enable`| If true, use custom PVC for storage |``|
 | `puppetdb.customPersistentVolumeClaim.storage.config`| Configuration for custom PVC for storage |``|
 | `puppetdb.extraContainers`| Extra containers to inject into the puppetdb pod |``|
+| `puppetdb.extraInitContainers`| Extra initContainers to inject into the puppetdb pod |``|
 | `puppetdb.serviceAccount.enabled`| Enable service account (Note: Service Account will only be automatically created if `puppetdb.serviceAccount.create` is not set.  |`false`|
+| `puppetdb.customconfigs.enabled`| puppetdb additional config map enabled |`false`|
+
 | `puppetdb.serviceAccount.create`| puppetdb additional masters svc labels |`false`|
 | `puppetdb.rbac.create`| Enable PodSecurityPolicy's RBAC rules |`false`|
 | `puppetdb.psp.create`| Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later |`false`|
@@ -336,10 +347,6 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `hiera.config`| hieradata yaml config |``|
 | `hiera.eyaml.private_key`| hiera eyaml private key |``|
 | `hiera.eyaml.public_key`| hiera eyaml public key |``|
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | [] |
-| `global.credentials.username`| puppetdb and postgresql username |`puppetdb`|
-| `global.credentials.password`| puppetdb and postgresql password |`unbreakablePassword`|
-| `global.credentials.existingSecret`| existing k8s secret that holds puppetdb and postgresql username and password |``|
 | `nameOverride`| puppetserver components name for `component:` labels |``|
 | `nodeSelector`| Node labels for pod assignment |``|
 | `affinity`| Affinity for pod assignment |``|

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -22,10 +22,10 @@ Hieradata Repo: "{{.Values.hiera.hieradataurl}}"
 {{- end }}
 
 {{ if .Values.hiera.eyaml.existingMap -}}
-WARNING: you specified a ConfigMap for eyaml secret and it unsecure 
+WARNING: you specified a ConfigMap for eyaml secret and it unsecure
 {{- end }}
 {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) }}
-WARNING: you specified a eyaml keys inside the values.yaml and it unsecure 
+WARNING: you specified a eyaml keys inside the values.yaml and it unsecure
 {{- end }}
 
 If you need to get your password for PuppetDB and PostgreSQL:

--- a/templates/puppetdb-customconfigs-configmap.yaml
+++ b/templates/puppetdb-customconfigs-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.puppetdb.customconfigs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: puppetdb-custom-configs
+  labels:
+    {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
+data:
+{{- toYaml .Values.puppetdb.customconfigs.configmaps | nindent 2 }}
+{{- end }}
+

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "puppetserver.puppetdb.labels" . | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations:
+        {{- if .Values.puppetdb.customconfigs.enabled }}
+        checksum/custom-configs.configmap: {{ include (print $.Template.BasePath "/puppetdb-customconfigs-configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
@@ -28,6 +31,61 @@ spec:
       {{- if .Values.puppetdb.serviceAccount.enabled }}
       serviceAccountName: {{ include "puppetserver.puppetdb.serviceAccount.name" . }}
       {{- end }}
+      initContainers:
+        {{- with .Values.puppetdb.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: pgchecker
+          image: "{{.Values.global.pgchecker.image}}:{{.Values.global.pgchecker.tag}}"
+          imagePullPolicy: {{.Values.global.pgchecker.imagePullPolicy}}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+          command:
+            - sh
+            - -c
+            - |
+              echo 'Waiting for PostgreSQL to become ready...'
+              until printf "." && nc -z -w 2 {{ include "postgresql.hostname" . }} 5432; do
+                  sleep 2;
+              done;
+              echo 'PostgreSQL OK ✓'
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              cpu: 20m
+              memory: 32Mi
+        - name: wait-puppetserver
+          image: "{{.Values.global.curl.image}}:{{.Values.global.curl.tag}}"
+          imagePullPolicy: {{.Values.global.curl.imagePullPolicy}}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+          command:
+            - sh
+            - -c
+            - |
+              echo 'Waiting for puppetserver to become ready...'
+              until curl --silent --fail --insecure 'https://puppet:{{ template "puppetserver.puppetserver-masters.port" . }}/status/v1/simple' | grep -q '^running$'; do
+                sleep 2;
+              done;
+              echo 'Puppetserver OK ✓'
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              cpu: 20m
+              memory: 32Mi
+        {{- if .Values.puppetdb.extraInitContainers }}
+        {{- toYaml .Values.puppetdb.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         {{- with .Values.puppetdb.extraContainers }}
           {{- toYaml . | nindent 8 }}
@@ -44,7 +102,7 @@ spec:
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             {{- if not (hasKey .Values.puppetdb.extraEnv "PUPPETDB_POSTGRES_HOSTNAME") }}
             - name: PUPPETDB_POSTGRES_HOSTNAME
-              value: "{{ template "puppetserver.name" . }}-postgresql"
+              value: "{{ include "postgresql.hostname" . }}"
             {{- end }}
             - name: PUPPETDB_PASSWORD
               valueFrom:
@@ -76,6 +134,11 @@ spec:
               mountPath: /etc/puppetlabs/puppetdb/conf.d/metrics.conf
               subPath: metrics.conf
             {{- end -}}
+            {{- range $key, $value := .Values.puppetdb.customconfigs.configmaps }}
+            - name: puppetdb-custom-configs
+              mountPath: /etc/puppetlabs/puppetdb/conf.d/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
         {{- if .Values.puppetboard.enabled }}
         - name: puppetboard
           image: "{{.Values.puppetboard.image}}:{{.Values.puppetboard.tag}}"
@@ -95,6 +158,11 @@ spec:
               value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/puppetdb.pem"
             - name: PUPPETBOARD_PORT
               value: {{ .Values.puppetboard.port | quote }}
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: puppetdb-puppetboard
+                  key: SECRET_KEY
             {{- range $key, $value := .Values.puppetboard.extraEnv }}
             - name: {{ $key }}
               value: "{{ $value }}"
@@ -176,6 +244,11 @@ spec:
         - name: puppetdb-metrics-volume
           configMap:
             name: puppetdb-metrics-config
+        {{- end }}
+        {{- if .Values.puppetdb.customconfigs.enabled }}
+        - name: puppetdb-custom-configs
+          configMap:
+            name: puppetdb-custom-configs
         {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/templates/puppetdb-secret.yaml
+++ b/templates/puppetdb-secret.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.global.credentials.existingSecret -}}
+{{- if .Values.puppetdb.enabled }}
+{{- if not .Values.global.postgresql.auth.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +8,22 @@ metadata:
     {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
 type: Opaque
 data:
-  username: {{ .Values.global.credentials.username | b64enc | quote }}
-  password: {{ include "postgresql.password" . | b64enc | quote }}
-{{- end -}}
+  username: {{ .Values.global.postgresql.auth.username | b64enc | quote }}
+  password: {{ .Values.global.postgresql.auth.password | b64enc | quote }}
+{{- end }}
+---
+{{- if .Values.puppetboard.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: puppetdb-puppetboard
+type: Opaque
+data:
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace "puppetdb-puppetboard" }}
+  {{- if $secret }}
+  SECRET_KEY: {{ $secret.data.SECRET_KEY }}
+  {{- else }}
+  SECRET_KEY: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -101,7 +101,7 @@ spec:
               chown puppet:puppet /etc/puppetlabs/puppet/eyaml/keys/*public_key.pkcs7.pem;
               {{- end }}
               {{- end }}
-              cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
+              cp /tmp/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
               {{- if .Values.singleCA.enabled }}
               cp /etc/puppetlabs/puppet/configmap/crl_entrypoint.sh /etc/puppetlabs/puppet/ssl/crl_entrypoint.sh;
@@ -166,7 +166,7 @@ spec:
               subPath: check_for_masters.sh
             {{- end }}
             - name: manifests-volume
-              mountPath: /etc/puppetlabs/puppet/configmap/site.pp
+              mountPath: /tmp/puppet/configmap/site.pp
               subPath: site.pp
             {{- if .Values.singleCA.enabled }}
             - name: crl-volume

--- a/templates/puppetserver-hpa-compilers.yaml
+++ b/templates/puppetserver-hpa-compilers.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.puppetserver.compilers.enabled }}
 {{- if .Values.puppetserver.compilers.autoScaling.enabled }}
-apiVersion: autoscaling/v2
+apiVersion: {{ include "puppetserver.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "puppetserver.name" . }}-compilers-autoscaler

--- a/templates/puppetserver-hpa-masters.yaml
+++ b/templates/puppetserver-hpa-masters.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.puppetserver.masters.multiMasters.enabled }}
 {{- if .Values.puppetserver.masters.multiMasters.autoScaling.enabled }}
-apiVersion: autoscaling/v2
+apiVersion: {{ include "puppetserver.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "puppetserver.name" . }}-masters-autoscaler

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -87,7 +87,7 @@ spec:
               cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
               chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
               {{- end }}
-              cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
+              cp /tmp/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
               chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
               {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret) }}
               cp /etc/puppetlabs/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
@@ -146,7 +146,7 @@ spec:
               subPath: hiera.yaml
             {{- end }}
             - name: manifests-volume
-              mountPath: /etc/puppetlabs/puppet/configmap/site.pp
+              mountPath: /tmp/puppet/configmap/site.pp
               subPath: site.pp
             {{- if and ( or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) }}
             - name: eyaml-volume

--- a/templates/update-crl-configmap.yaml
+++ b/templates/update-crl-configmap.yaml
@@ -32,7 +32,7 @@ data:
 
     exit $retVal
     {{- end }}
-    
+
   crl_cronjob.sh: |
     #!/usr/bin/env sh
     $SSL_PATH/crl.sh > ~/.crl_cronjob.out 2>&1
@@ -57,4 +57,5 @@ data:
     # tail -Fq ~/.crl_cronjob.out &
     touch ~/.crl_cronjob.success > /dev/null 2>&1
     exec supercronic ~/.crl_crontab
+
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,12 +2,40 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+## Global Values
+##
+global:
+  curl:
+    image: curlimages/curl
+    tag: 7.87.0
+    imagePullPolicy: IfNotPresent
+
+  imagePullSecrets:
+
+  pgchecker:
+    image: docker.io/busybox
+    tag: 1.36
+    imagePullPolicy: IfNotPresent
+
+  ## Credentials for PuppetDB and PostgreSQL
+  postgresql:
+    auth:
+      username: puppetdb
+      password: unbreakablePassword
+      postgresPassword: unbreakableAdminPassword
+      database: puppetdb
+
+      existingSecret: ""
+      secretKeys:
+        usernameKey: username
+        userPasswordKey: password
+
 ## Puppet Server Configuration
 ##
 puppetserver:
   name: puppetserver
   image: puppet/puppetserver
-  tag: 7.4.2
+  tag: 7.9.2
   pullPolicy: IfNotPresent
   ## Mandatory Deployment of Puppet Server Master/s
   ##
@@ -483,7 +511,7 @@ puppetdb:
   enabled: true
   name: puppetdb
   image: puppet/puppetdb
-  tag: 7.7.1
+  tag: 7.10.0
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -494,6 +522,9 @@ puppetdb:
   #    cpu: 1000m
   ## Extra containers to inject into the PuppetDB pod
   extraContainers: []
+
+  ## Extra initContainers to inject into the PuppetDB pod
+  extraInitContainers: []
   ## Additional puppetdb container environment variables
   extraEnv: {}
 
@@ -518,6 +549,14 @@ puppetdb:
     labels: {}
     loadBalancerIP: ""
     clusterIP: ""
+
+  ## Custom puppetdb conf.d configs
+  ##
+  customconfigs:
+    enabled: false
+    configmaps: {}
+    #  auth.conf: |-
+    #    {}
 
   ## puppetdb metrics enable/disable flag
   metrics:
@@ -544,58 +583,22 @@ puppetdb:
 ##
 postgresql:
   enabled: true
-  name: postgresql
-  ## Set fullnameOverride to match this chart's name
-  ##
-  fullnameOverride: puppetserver-postgresql
-  ## Configure resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
-  # resources:
-  #  requests:
-  #    memory: 512Mi
-  #    cpu: 500m
-  #  limits:
-  #    memory: 1024Mi
-  #    cpu: 1000m
-  ## Create a database
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
-  ##
-  postgresqlDatabase: puppetdb
-  ## Specify the PostgreSQL username and password to execute the initdb scripts
-  ##
-  initdbUser: postgres
-  ## ConfigMap with scripts to be run at first boot
-  ## NOTE: This will override initdbScripts
-  ##
-  initdbScriptsConfigMap: postgresql-custom-extensions
-  ## PostgreSQL data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  persistence:
-    enabled: true
-    ## A manually managed Persistent Volume and Claim
-    ## If defined, PVC must be created manually before volume will be bound
-    ## The value is evaluated as a template, so, for example, the name can depend on .Release or .Chart
-    ##
-    # existingClaim:
-    size: 10Gi
-    annotations:
-      ## The annotation instructs Helm to skip deleting this resource
-      ## when a helm operation (such as helm uninstall, helm upgrade or helm rollback)
-      ## would result in its deletion.
-      ##
-      helm.sh/resource-policy: keep
-  ## Replication settings
-  ## Please check: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
-  ##
-  replication:
-    enabled: false
-    slaveReplicas: 1
+
+  architecture: standalone
+
+  primary:
+    initdb:
+      scriptsConfigMap: "postgresql-custom-extensions"
+    persistence:
+      enabled: true
+      size: 10Gi
+      annotations:
+        ## The annotation instructs Helm to skip deleting this resource
+        ## when a helm operation (such as helm uninstall, helm upgrade or helm rollback)
+        ## would result in its deletion.
+        ##
+        helm.sh/resource-policy: keep
+
 
 ## Puppetboard Configuration
 ##
@@ -603,7 +606,7 @@ puppetboard:
   enabled: false
   name: puppetboard
   image: ghcr.io/voxpupuli/puppetboard
-  tag: 3.3.0
+  tag: 4.2.4
   port: 9090
   pullPolicy: IfNotPresent
   service:
@@ -706,18 +709,6 @@ hiera:
     public_key:  # |
       #  PUB_KEY CONTENTS
 
-## Global Values
-##
-global:
-  ## Credentials for PuppetDB and PostgreSQL
-  ##
-  credentials:
-    username: puppetdb
-    password: ""
-    ## If used, the following existing secret must contain "username" and "password" keys.
-    ## NOTE: Using this secret supercedes all other credentials settings.
-    ##
-    existingSecret: ""
 
 ## Provide a name in place of Puppet Server components for `app:` labels
 ##


### PR DESCRIPTION
- fix: postgresql dependency (upgrade to the lastest available chart `12.1.6`)
- feat: add 2 init container on puppetdb deployment to start only when postgresql & puppet master is ready
- feat: allow custom config on puppetdb
- feat: bump Puppetserver to `v7.9.2`.
- feat: bump PuppetDB to `v7.10.0`.
- feat: bump Puppetboard to `v4.2.4`.
- fix: move configmap in /tmp to avoid Read Only error in puppetserver init container