### PR TITLE
remove `timeout [-t SECS]` for new r10k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v7.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.2.1) (2023-01-23)
+- Fix: remove `timeout [-t SECS]` change from BusyBox v1.29.3 to BusyBox v1.33.1 `timeout SECS`
+
 ## [v7.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.2.0) (2023-01-18)
 - Fix: puppetdb pvc deletion when preinstall job finnish before puppetdb pod start
 - Feat: Allow crl to be updated as Kubernetes cron job instead of pod side car (share the crl between all deployment)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 7.2.0
+version: 7.2.1
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -31,7 +31,7 @@ data:
     {{- if .Values.r10k.code.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.code.cronJob.splayLimit }} ))
     {{- end }}
-    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 -t {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
+    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
     --puppetfile {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -33,7 +33,7 @@ data:
     {{- if .Values.r10k.hiera.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.hiera.cronJob.splayLimit }} ))
     {{- end }}
-    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 -t {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
+    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
     --puppetfile {{ template "r10k.hiera.args" . }} > ~/.r10k_hiera_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then


### PR DESCRIPTION
Remove `timeout [-t SECS]` change from BusyBox v1.29.3 to BusyBox v1.33.1 `timeout SECS` due to change of r10k container from <= v3.14.0 to v3.15.2