### PR TITLE
Add additional needed CAP permissions for puppetdb

### DIFF
--- a/templates/puppetserver-init-configmap.yaml
+++ b/templates/puppetserver-init-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   check_for_masters.sh: |
     #!/usr/bin/env bash
-    PUPPET_SSL_CERT_PEM=/etc/puppetlabs/puppet/ssl/certs/puppet.pem
+    PUPPET_SSL_CERT_PEM="/etc/puppetlabs/puppet/ssl/certs/$(puppet config print certname).pem"
     if [[ -d "$PUPPET_SSL_DIR" ]]; then
         echo "A Puppetserver master has already started running."
         echo "Waiting to finish the generation of the Puppet SSL certs..."

--- a/values.yaml
+++ b/values.yaml
@@ -570,12 +570,12 @@ puppetdb:
     capabilities:
       drop:
         - all
-			add:
-				- CAP_FOWNER
-				- CAP_CHOWN
-				- CAP_SETUID
-				- CAP_SETGID
-				- CAP_DAC_OVERRIDE
+      add:
+        - CAP_FOWNER
+        - CAP_CHOWN
+        - CAP_SETUID
+        - CAP_SETGID
+        - CAP_DAC_OVERRIDE
   extraContainers: []
 
   ## Extra initContainers to inject into the PuppetDB pod

--- a/values.yaml
+++ b/values.yaml
@@ -570,10 +570,12 @@ puppetdb:
     capabilities:
       drop:
         - all
-      add:
-        - CAP_SETUID
-        - CAP_SETGID
-        - CAP_DAC_OVERRIDE
+			add:
+				- CAP_FOWNER
+				- CAP_CHOWN
+				- CAP_SETUID
+				- CAP_SETGID
+				- CAP_DAC_OVERRIDE
   extraContainers: []
 
   ## Extra initContainers to inject into the PuppetDB pod


### PR DESCRIPTION
Pretty simple pull request. It's simply adding the additional CAP permissions needed for PuppetDB to run. This is due to a chown operation being run when the service starts.,