### PR TITLE
fix minor issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v7.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.0) (2023-02-17)
+- Fix: Remove r10k & hiera configuration in preinstall job
+- Fix: Preserve the whole tree file under /etc/puppetlabs/puppetserver when using the chart asNonRoot
+- Fix: Add capability compatibility for Azure
+- FIx: Manage hiera config in deployment to reload the pod automatically
+
+
 ## [v7.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.0) (2023-02-06)
 - Feat: allow to `runAsNonRoot` puppetserver **deployement** (masters & compilers) pods
 - Feat: add `PodDisruptionBudget`

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.customPersistentVolumeClaim.ca.config`| Configuration for custom PVC for certificate |``|
 | `puppetserver.customPersistentVolumeClaim.confd.enable`| If true, use custom PVC for conf.d  |``|
 | `puppetserver.customPersistentVolumeClaim.confd.config`| Configuration for custom PVC for conf.d |``|
+| `puppetserver.customPersistentVolumeClaim.puppetserver.enable`| If true, use custom PVC for puppetserver  |``|
+| `puppetserver.customPersistentVolumeClaim.puppetserver.config`| Configuration for custom PVC for puppetserver |``|
 | `puppetserver.masters.resources` | puppetserver masters resource limits | ``|
 | `puppetserver.masters.podAntiAffinity` | puppetserver masters pod affinity constraints |`false`|
 | `puppetserver.masters.podDisruptionBudget.enabled` | enable PodDisruptionBudget on puppetserver masters | `false`|

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -51,30 +51,10 @@ spec:
               mkdir -p /etc/puppetlabs/code/r10k_cache;
               mkdir -p /opt/puppetlabs/server/data/puppetserver/dropsonde/bin/;
               touch /opt/puppetlabs/server/data/puppetserver/dropsonde/bin/dropsonde;
-              {{- if .Values.r10k.asSidecar }}
-              {{- if .Values.puppetserver.puppeturl }}
-              echo "Copy r10k code config"
-              cp /tmp/puppet/configmap/r10k_code_entrypoint.sh /etc/puppetlabs/puppet/r10k_code_entrypoint.sh;
-              cp /tmp/puppet/configmap/r10k_code_cronjob.sh /etc/puppetlabs/puppet/r10k_code_cronjob.sh;
-              cp /tmp/puppet/configmap/r10k_code.yaml /etc/puppetlabs/puppet/r10k_code.yaml;
-              chmod +x /etc/puppetlabs/puppet/r10k_code_entrypoint.sh /etc/puppetlabs/puppet/r10k_code_cronjob.sh;
-              {{- end }}
-              {{- if (include "hiera.enable" .) }}
-              echo "Copy r10k hiera config"
-              cp /tmp/puppet/configmap/r10k_hiera_entrypoint.sh /etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh;
-              cp /tmp/puppet/configmap/r10k_hiera_cronjob.sh /etc/puppetlabs/puppet/r10k_hiera_cronjob.sh;
-              cp /tmp/puppet/configmap/r10k_hiera.yaml /etc/puppetlabs/puppet/r10k_hiera.yaml;
-              chmod +x /etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh /etc/puppetlabs/puppet/r10k_hiera_cronjob.sh;
-              {{- end }}
-              {{- if .Values.hiera.config }}
-              echo "Copy hiera config"
-              cp /tmp/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
-              {{- end }}
               {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret) }}
               echo "Copy eyaml config"
               cp /tmp/puppet/configmap/eyaml/*private_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
               cp /tmp/puppet/configmap/eyaml/*public_key.pkcs7.pem /etc/puppetlabs/puppet/eyaml/keys/;
-              {{- end }}
               {{- end }}
               echo "Update files owner to puppet:puppet in /etc/puppetlabs/";
               chown -R puppet:puppet /etc/puppetlabs/ -v;
@@ -83,47 +63,18 @@ spec:
               {{- if .Values.puppetserver.extraInitArgs }}
               {{- .Values.puppetserver.extraInitArgs | nindent 14 }}
               {{- end }}
-              echo "copy conf.d files";
-              cp -rp /etc/puppetlabs/puppetserver/conf.d/* /conf.d/;
+              echo "copy puppetserver files";
+              cp -rp /etc/puppetlabs/puppetserver/* /puppetserver/;
+              echo "copy puppet files";
+              cp -rp /etc/puppetlabs/puppet/* /puppet/;
           volumeMounts:
-            - name: puppet-confd
-              mountPath: /conf.d/
+            - name: puppet-puppetserver
+              mountPath: /puppetserver/
             - name: puppet-puppet-storage
-              mountPath: /etc/puppetlabs/puppet/
+              mountPath: /puppet/
             {{- if and .Values.puppetserver.puppeturl (not .Values.puppetserver.compilers.enabled) }}
             - name: puppet-code-storage
               mountPath: /etc/puppetlabs/code/
-            {{- if .Values.r10k.asSidecar }}
-            - name: r10k-code-volume
-              mountPath: /tmp/puppet/configmap/r10k_code_entrypoint.sh
-              subPath: r10k_code_entrypoint.sh
-            - name: r10k-code-volume
-              mountPath: /tmp/puppet/configmap/r10k_code_cronjob.sh
-              subPath: r10k_code_cronjob.sh
-            - name: r10k-code-volume
-              mountPath: /tmp/puppet/configmap/r10k_code.yaml
-              subPath: r10k_code.yaml
-            {{- if and (include "hiera.enable" .) }}
-            - name: r10k-hiera-volume
-              mountPath: /tmp/puppet/configmap/r10k_hiera_entrypoint.sh
-              subPath: r10k_hiera_entrypoint.sh
-            - name: r10k-hiera-volume
-              mountPath: /tmp/puppet/configmap/r10k_hiera_cronjob.sh
-              subPath: r10k_hiera_cronjob.sh
-            - name: r10k-hiera-volume
-              mountPath: /tmp/puppet/configmap/r10k_hiera.yaml
-              subPath: r10k_hiera.yaml
-            {{- end }}
-            {{- end }}
-            {{- if .Values.hiera.config }}
-            - name: hiera-volume
-              mountPath: /tmp/puppet/configmap/hiera.yaml
-              subPath: hiera.yaml
-            {{- end }}
-            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
-            - name: eyaml-volume
-              mountPath: /tmp/puppet/configmap/eyaml
-            {{- end }}
             {{- if and (or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key)) (not .Values.hiera.eyaml.existingSecret)}}
             - name: eyamlpub-volume
               mountPath: /tmp/puppet/configmap/eyaml/public_key.pkcs7.pem
@@ -148,6 +99,12 @@ spec:
                 - CAP_DAC_OVERRIDE
                 - CAP_AUDIT_WRITE
                 - CAP_FOWNER
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - AUDIT_WRITE
+                - FOWNER
           {{- end }}
       containers:
         {{- if or .Values.puppetserver.preGeneratedCertsJob.enabled .Values.singleCA.enabled }}
@@ -287,8 +244,8 @@ spec:
           ports:
             - containerPort: {{ template "puppetserver.puppetserver-masters.port" .}}
           volumeMounts:
-            - name: puppet-confd
-              mountPath: /etc/puppetlabs/puppetserver/conf.d/
+            - name: puppet-puppetserver
+              mountPath: /etc/puppetlabs/puppetserver/
             - name: puppet-docker-entrypoint-config
               mountPath: /docker-entrypoint.sh
               subPath: docker-entrypoint.sh
@@ -323,6 +280,12 @@ spec:
                 - CAP_DAC_OVERRIDE
                 - CAP_AUDIT_WRITE
                 - CAP_FOWNER
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - AUDIT_WRITE
+                - FOWNER
         {{- end }}
       hostAliases:
         - ip: 127.0.0.1
@@ -341,9 +304,9 @@ spec:
             claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
         {{- end }}
         {{- if .Values.global.runAsNonRoot }}
-        - name: puppet-confd
+        - name: puppet-puppetserver
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-confd-claim
+            claimName: {{ template "puppetserver.fullname" . }}-puppetserver-claim
         - name: puppet-code-storage
         {{- if .Values.puppetserver.customPersistentVolumeClaim.code.enable }}
           {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.code.config | nindent 10 }}
@@ -380,36 +343,13 @@ spec:
             name: {{ template "puppetserver.fullname" . }}-customentrypoints
             defaultMode: 0777
         {{- end }}
-        {{- if .Values.hiera.config }}
-        - name: hiera-volume
-          configMap:
-            name: {{ template "puppetserver.fullname" . }}-hiera-config
-        {{- end }}
-        {{- if .Values.hiera.eyaml.existingSecret }}
-        - name: eyaml-volume
-          secret:
-            secretName: {{ .Values.hiera.eyaml.existingSecret }}
-        {{- else if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) }}
+        {{- if or (.Values.hiera.eyaml.public_key) (.Values.hiera.eyaml.private_key) }}
         - name: eyamlpub-volume
           secret:
             secretName: {{ template "puppetserver.hiera.publicSecret" . }}
         - name: eyamlpriv-volume
           secret:
             secretName: {{ template "puppetserver.hiera.privateSecret" . }}
-        {{- else if .Values.hiera.eyaml.existingMap  }}
-        - name: eyaml-volume
-          configMap:
-            name: {{ .Values.hiera.eyaml.existingMap }}
-        {{- end }}
-        {{- if (include "hiera.enable" .) }}
-        - name: r10k-hiera-volume
-          configMap:
-            name: {{ template "puppetserver.fullname" . }}-r10k-hiera-config
-        {{- end }}
-        {{- if .Values.puppetserver.puppeturl }}
-        - name: r10k-code-volume
-          configMap:
-            name: {{ template "puppetserver.fullname" . }}-r10k-code-config
         {{- end }}
         {{- end }}
         {{- range $extraSecret := .Values.puppetserver.extraSecrets }}

--- a/templates/puppetdb-podsecuritypolicy.yaml
+++ b/templates/puppetdb-podsecuritypolicy.yaml
@@ -23,6 +23,11 @@ spec:
     - CAP_SETUID
     - CAP_SETGID
     - CAP_DAC_OVERRIDE
+    - FOWNER
+    - CHOWN
+    - SETUID
+    - SETGID
+    - DAC_OVERRIDE
   volumes:
     - 'configMap'
     - 'secret'

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -127,6 +127,12 @@ spec:
                 - CAP_DAC_OVERRIDE
                 - CAP_AUDIT_WRITE
                 - CAP_FOWNER
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - AUDIT_WRITE
+                - FOWNER
           volumeMounts:
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
@@ -263,8 +269,20 @@ spec:
               subPath: {{ $key }}
             {{- end }}
             {{- if .Values.global.runAsNonRoot }}
+            - name: puppet-puppetserver
+              mountPath: /etc/puppetlabs/puppetserver/
+            {{- else }}
             - name: puppet-confd
               mountPath: /etc/puppetlabs/puppetserver/conf.d/
+            {{- end }}
+            {{- if .Values.hiera.config }}
+            - name: hiera-volume
+              mountPath: /etc/puppetlabs/puppet/hiera.yaml
+              subPath: hiera.yaml
+            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
+            - name: eyaml-volume
+              mountPath: /etc/puppetlabs/puppet/eyaml/keys
+            {{- end }}
             {{- end }}
           securityContext:
             {{- if .Values.global.runAsNonRoot }}
@@ -552,6 +570,10 @@ spec:
             name: {{ .Values.hiera.eyaml.existingMap }}
         {{- end }}
         {{- if .Values.global.runAsNonRoot }}
+        - name: puppet-puppetserver
+          persistentVolumeClaim:
+            claimName: {{ template "puppetserver.fullname" . }}-puppetserver-claim
+        {{- else }}
         - name: puppet-confd
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.fullname" . }}-confd-claim

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -138,6 +138,12 @@ spec:
                 - CAP_DAC_OVERRIDE
                 - CAP_AUDIT_WRITE
                 - CAP_FOWNER
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - AUDIT_WRITE
+                - FOWNER
           volumeMounts:
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
@@ -275,12 +281,24 @@ spec:
               subPath: {{ $key }}
             {{- end }}
             {{- if .Values.global.runAsNonRoot }}
+            - name: puppet-puppetserver
+              mountPath: /etc/puppetlabs/puppetserver/
+              {{- else }}
             - name: puppet-confd
               mountPath: /etc/puppetlabs/puppetserver/conf.d/
             {{- end }}
             {{- if (not .Values.puppetserver.compilers.enabled) }}
             - name: puppet-code-storage
               mountPath: /etc/puppetlabs/code/
+            {{- if .Values.hiera.config }}
+            - name: hiera-volume
+              mountPath: /etc/puppetlabs/puppet/hiera.yaml
+              subPath: hiera.yaml
+            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
+            - name: eyaml-volume
+              mountPath: /etc/puppetlabs/puppet/eyaml/keys
+            {{- end }}
+            {{- end }}
             {{- end }}
           securityContext:
             {{- if .Values.global.runAsNonRoot }}
@@ -584,6 +602,10 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.global.runAsNonRoot }}
+        - name: puppet-puppetserver
+          persistentVolumeClaim:
+            claimName: {{ template "puppetserver.fullname" . }}-puppetserver-claim
+        {{- else }}
         - name: puppet-confd
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.fullname" . }}-confd-claim

--- a/templates/puppetserver-podsecuritypolicy.yaml
+++ b/templates/puppetserver-podsecuritypolicy.yaml
@@ -29,6 +29,12 @@ spec:
     - CAP_DAC_OVERRIDE
     - CAP_AUDIT_WRITE
     - CAP_FOWNER
+    - CHOWN
+    - SETUID
+    - SETGID
+    - DAC_OVERRIDE
+    - AUDIT_WRITE
+    - FOWNER
   volumes:
     - 'configMap'
     - 'secret'

--- a/templates/puppetserver-puppetserver-pvc.yaml
+++ b/templates/puppetserver-puppetserver-pvc.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.puppetserver.customPersistentVolumeClaim.confd.enable) (not .Values.global.runAsNonRoot) }}
+{{- if and (not .Values.puppetserver.customPersistentVolumeClaim.puppetserver.enable) .Values.global.runAsNonRoot }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "puppetserver.fullname" . }}-confd-claim
+  name: {{ template "puppetserver.fullname" . }}-puppetserver-claim
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
     {{- with .Values.global.extraLabels }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -132,6 +132,12 @@ spec:
                 - CAP_DAC_OVERRIDE
                 - CAP_AUDIT_WRITE
                 - CAP_FOWNER
+                - CHOWN
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+                - AUDIT_WRITE
+                - FOWNER
           volumeMounts:
             - name: puppet-code-volume
               mountPath: /etc/puppetlabs/code/

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,9 @@ puppetserver:
     confd:
       enable: false
       config: {}
+    puppetserver:
+      enable: false
+      config: {}
 
   ## Mandatory Deployment of Puppet Server Master/s
   ##
@@ -470,6 +473,12 @@ puppetserver:
         - CAP_DAC_OVERRIDE
         - CAP_AUDIT_WRITE
         - CAP_FOWNER
+        - CHOWN
+        - SETUID
+        - SETGID
+        - DAC_OVERRIDE
+        - AUDIT_WRITE
+        - FOWNER
   ## The pattern of managing Hieradata in a separate repository is
   ## both common and acceptable. Doing so provides the ability to decouple
   ## the management of configuration data from that of the Puppet code base.
@@ -621,6 +630,11 @@ puppetdb:
         - CAP_SETUID
         - CAP_SETGID
         - CAP_DAC_OVERRIDE
+        - FOWNER
+        - CHOWN
+        - SETUID
+        - SETGID
+        - DAC_OVERRIDE
 
   networkPolicy:
     enabled: false


### PR DESCRIPTION
- Fix: Remove r10k & hiera configuration in preinstall job
- Fix: Preserve the whole tree file under /etc/puppetlabs/puppetserver when using the chart asNonRoot
- Fix: Add capability compatibility for Azure
- FIx: Manage hiera config in deployment to reload the pod automatically