### PR TITLE
Fix ca backup template for non standard fullname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v7.4.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.3) (2023-05-10)
+- Fix: puppet ca cronjob pvc claim name
 
 ## [v7.4.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.2) (2023-03-14)
 - Fix: puppet master deployment issue when running as root

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 7.4.2
+version: 7.4.3
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -52,17 +52,17 @@ spec:
             - name: RESTIC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: restic-backup-creds
+                  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
                   key: restic_password
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: restic-backup-creds
+                  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
                   key: access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: restic-backup-creds
+                  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
                   key: secret_access_key
             volumeMounts:
             - name: puppet-ca-storage

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -75,13 +75,13 @@ spec:
             {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.ca.config | nindent 10 }}
           {{- else }}
             persistentVolumeClaim:
-              claimName: puppet-ca-claim
+              claimName: {{ template "puppetserver.fullname" . }}-ca-claim
           {{- end }}
           - name: puppet-puppet-storage
           {{- if .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
             {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.puppet.config | nindent 10 }}
           {{- else }}
             persistentVolumeClaim:
-              claimName: puppet-puppet-claim
+              claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
           {{- end }}
 {{- end }}


### PR DESCRIPTION
If the `puppetserver.fullname`does not match the default `puppetserver` the CA backup fails. (For example if you use a `nameOverride`)

Using `puppetserver.fullname` instead of static names fixes this.
