### PR TITLE
pgchecker doesn't work with external database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v7.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.1) (2023-02-11)
+- Fix: change postgresql.hosname logic to allow for external servers
+
 ## [v7.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.0) (2023-02-06)
 - Feat: allow to `runAsNonRoot` puppetserver **deployement** (masters & compilers) pods
 - Feat: add `PodDisruptionBudget`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v7.4.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.4) (2023-05-31)
+- Fix: pgchecker doesn't work with external database. Added the possibility of setting external postgresql.hostname with .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME
+
 ## [v7.4.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.3) (2023-05-10)
 - Fix: puppet ca cronjob pvc claim name
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 7.4.0
+version: 7.4.1
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 7.4.3
+version: 7.4.4
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -429,6 +429,10 @@ Return PostgreSQL host name
 {{- else }}
 {{- printf "%s-%s" .Release.Name "postgresql-primary-hl" | trimSuffix "-" -}}
 {{- end -}}
+{{- else }}
+{{- if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME }}
+{{- printf "%s" .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -429,10 +429,8 @@ Return PostgreSQL host name
 {{- else }}
 {{- printf "%s-%s" .Release.Name "postgresql-primary-hl" | trimSuffix "-" -}}
 {{- end -}}
-{{- else }}
-{{- if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME }}
+{{- else if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME }}
 {{- printf "%s" .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -426,8 +426,6 @@ Return PostgreSQL host name
 {{- if .Values.postgresql.enabled }}
 {{- if eq .Values.postgresql.architecture "standalone" -}}
 {{- printf "%s-%s" .Release.Name "postgresql-hl" | trimSuffix "-" -}}
-{{- else if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
-{{- printf "%s" .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
 {{- else }}
 {{- printf "%s-%s" .Release.Name "postgresql-primary-hl" | trimSuffix "-" -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -426,6 +426,8 @@ Return PostgreSQL host name
 {{- if .Values.postgresql.enabled }}
 {{- if eq .Values.postgresql.architecture "standalone" -}}
 {{- printf "%s-%s" .Release.Name "postgresql-hl" | trimSuffix "-" -}}
+{{- else if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
+{{- printf "%s" .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
 {{- else }}
 {{- printf "%s-%s" .Release.Name "postgresql-primary-hl" | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
Added the possibility of setting external postgresql.hostname with .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME