### PR TITLE
Rework persistence to allow teaking individual PVCs while keeping them controlled by the chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 7.4.5
+version: 8.0.0
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ horizontalpodautoscaler.autoscaling/puppetserver-compilers-autoscaler   Stateful
 
 ## Upgrading
 
-### from 7.4.5 to TBD
+### from 7.x to 8.0
 
 `customPersistentVolumeClaim` was removed instead check `puppetdb.persistence.existingClaim` or `puppetserver.persistence.*.existingClaim` for similar functionnality.
 

--- a/README.md
+++ b/README.md
@@ -571,3 +571,4 @@ kill %[job_numbers_above]
 * [Alexander Kiryushin](https://github.com/akiryushin), Contributor
 * [Ben Feld](https://github.com/rootshellz), Contributor
 * [Julien Godin](https://github.com/JGodin-C2C), Contributor
+* [Diego Abelenda](https://github.com/dabelenda), Contributor

--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ NAME                                                                    REFERENC
 horizontalpodautoscaler.autoscaling/puppetserver-compilers-autoscaler   StatefulSet/puppetserver-puppetserver-compilers   33%/75%, 47%/75%               1         3         0          9m25s
 ```
 
+## Upgrading
+
+### from 7.4.5 to TBD
+
+`customPersistentVolumeClaim` was removed instead check `puppetdb.persistence.existingClaim` or `puppetserver.persistence.*.existingClaim` for similar functionnality.
+
+Added support for setting the size and Storage Class of individual Persistent Volume Claims fullfilling most uses of `customPersistentVolumeClaim` check `puppetdb.persistence.size` `puppetdb.persistence.storageClass`, `puppetserver.persistence.*.storageClass` and `puppetserver.persistence.*.size` for more information.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Puppetserver chart and their default values.

--- a/README.md
+++ b/README.md
@@ -198,18 +198,36 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.image` | puppetserver image | `puppet/puppetserver`|
 | `puppetserver.tag` | puppetserver img tag | `6.12.1`|
 | `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
-| `puppetserver.customPersistentVolumeClaim.serverdata.enable`| If true, use custom PVC for puppet data |``|
-| `puppetserver.customPersistentVolumeClaim.serverdata.config`| Configuration for custom PVC for puppet data |``|
-| `puppetserver.customPersistentVolumeClaim.puppet.enable`| If true, use custom PVC for puppet |``|
-| `puppetserver.customPersistentVolumeClaim.puppet.config`| Configuration for custom PVC for puppet |``|
-| `puppetserver.customPersistentVolumeClaim.code.enable`| If true, use custom PVC for code  |``|
-| `puppetserver.customPersistentVolumeClaim.code.config`| Configuration for custom PVC for code |``|
-| `puppetserver.customPersistentVolumeClaim.ca.enable`| If true, use custom PVC for certificate  |``|
-| `puppetserver.customPersistentVolumeClaim.ca.config`| Configuration for custom PVC for certificate |``|
-| `puppetserver.customPersistentVolumeClaim.confd.enable`| If true, use custom PVC for conf.d  |``|
-| `puppetserver.customPersistentVolumeClaim.confd.config`| Configuration for custom PVC for conf.d |``|
-| `puppetserver.customPersistentVolumeClaim.puppetserver.enable`| If true, use custom PVC for puppetserver  |``|
-| `puppetserver.customPersistentVolumeClaim.puppetserver.config`| Configuration for custom PVC for puppetserver |``|
+| `puppetserver.persistence.data.existingClaim`| If non-empty, use a pre-defined PVC for puppet data |``|
+| `puppetserver.persistence.data.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.data.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.data.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
+| `puppetserver.persistence.data.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
+| `puppetserver.persistence.puppet.existingClaim`| If non-empty, use a pre-defined PVC for the puppet directory |``|
+| `puppetserver.persistence.puppet.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.puppet.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.puppet.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
+| `puppetserver.persistence.puppet.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
+| `puppetserver.persistence.code.existingClaim`| If non-empty, use a pre-defined PVC for the puppet code |``|
+| `puppetserver.persistence.code.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.code.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.code.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
+| `puppetserver.persistence.code.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
+| `puppetserver.persistence.ca.existingClaim`| If non-empty, use a pre-defined PVC for the puppet CA certificates |``|
+| `puppetserver.persistence.ca.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.ca.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.ca.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
+| `puppetserver.persistence.ca.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
+| `puppetserver.persistence.confd.existingClaim`| If non-empty, use a pre-defined PVC for the puppet conf.d directory |``|
+| `puppetserver.persistence.confd.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.confd.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.confd.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
+| `puppetserver.persistence.confd.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
+| `puppetserver.persistence.server.existingClaim`| If non-empty, use a pre-defined PVC for the puppetserver |``|
+| `puppetserver.persistence.server.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.server.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
+| `puppetserver.persistence.server.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
+| `puppetserver.persistence.server.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
 | `puppetserver.masters.resources` | puppetserver masters resource limits | ``|
 | `puppetserver.masters.podAntiAffinity` | puppetserver masters pod affinity constraints |`false`|
 | `puppetserver.masters.podDisruptionBudget.enabled` | enable PodDisruptionBudget on puppetserver masters | `false`|

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -146,6 +146,217 @@ app.kubernetes.io/component: {{ .Values.puppetserver.name }}-serverdata
 {{- end -}}
 
 {{/*
+Create the name for the Puppet Server Puppet Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.puppet.claimName" -}}
+{{- if .Values.puppetserver.persistence.puppet.existingClaim -}}
+  {{- .Values.puppetserver.persistence.puppet.existingClaim -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-puppet-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the Puppet Server Puppet Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.puppet.annotations" -}}
+{{- if .Values.puppetserver.persistence.puppet.annotations -}}
+  {{- .Values.puppetserver.persistence.puppet.annotations | toYaml -}}
+{{- else -}}
+{{- if .Values.storage.annotations -}}
+  {{- .Values.storage.annotations | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the Puppet Server Puppet Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.puppet.storageClass" -}}
+{{- if .Values.puppetserver.persistence.puppet.storageClass -}}
+  {{- .Values.puppetserver.persistence.puppet.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the Puppet Server Code Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.code.claimName" -}}
+{{- if .Values.puppetserver.persistence.code.existingClaim -}}
+  {{- .Values.puppetserver.persistence.code.existingClaim -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-code-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the Puppet Server Code Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.code.annotations" -}}
+{{- if .Values.puppetserver.persistence.code.annotations -}}
+  {{- .Values.puppetserver.persistence.code.annotations | toYaml -}}
+{{- else -}}
+{{- if .Values.storage.annotations -}}
+  {{- .Values.storage.annotations | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the Puppet Server Code Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.code.storageClass" -}}
+{{- if .Values.puppetserver.persistence.code.storageClass -}}
+  {{- .Values.puppetserver.persistence.code.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the Puppet Server Server Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.server.claimName" -}}
+{{- if .Values.puppetserver.persistence.server.existingClaim -}}
+  {{- .Values.puppetserver.persistence.server.existingClaim -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-puppetserver-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the Puppet Server Server Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.server.annotations" -}}
+{{- if .Values.puppetserver.persistence.server.annotations -}}
+  {{- .Values.puppetserver.persistence.server.annotations | toYaml -}}
+{{- else -}}
+{{- if .Values.storage.annotations -}}
+  {{- .Values.storage.annotations | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the Puppet Server Server Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.server.storageClass" -}}
+{{- if .Values.puppetserver.persistence.server.storageClass -}}
+  {{- .Values.puppetserver.persistence.server.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the Puppet Server Data Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.data.claimName" -}}
+{{- if .Values.puppetserver.persistence.data.existingClaim -}}
+  {{- .Values.puppetserver.persistence.data.existingClaim -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-serverdata-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the Puppet Server Data Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.data.annotations" -}}
+{{- if .Values.puppetserver.persistence.data.annotations -}}
+  {{- .Values.puppetserver.persistence.data.annotations | toYaml -}}
+{{- else -}}
+{{- if .Values.storage.annotations -}}
+  {{- .Values.storage.annotations | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the Puppet Server Data Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.data.storageClass" -}}
+{{- if .Values.puppetserver.persistence.data.storageClass -}}
+  {{- .Values.puppetserver.persistence.data.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the Puppet Server CA Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.ca.claimName" -}}
+{{- if .Values.puppetserver.persistence.ca.existingClaim -}}
+  {{- .Values.puppetserver.persistence.ca.existingClaim -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-ca-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the Puppet Server CA Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.ca.annotations" -}}
+{{- if .Values.puppetserver.persistence.ca.annotations -}}
+  {{- .Values.puppetserver.persistence.ca.annotations | toYaml -}}
+{{- else -}}
+{{- if .Values.storage.annotations -}}
+  {{- .Values.storage.annotations | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the Puppet Server CA Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.ca.storageClass" -}}
+{{- if .Values.puppetserver.persistence.ca.storageClass -}}
+  {{- .Values.puppetserver.persistence.ca.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the Puppet Server conf.d Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.confd.claimName" -}}
+{{- if .Values.puppetserver.persistence.confd.existingClaim -}}
+  {{- .Values.puppetserver.persistence.confd.existingClaim -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-confd-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the Puppet Server conf.d Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.confd.annotations" -}}
+{{- if .Values.puppetserver.persistence.confd.annotations -}}
+  {{- .Values.puppetserver.persistence.confd.annotations | toYaml -}}
+{{- else -}}
+{{- if .Values.storage.annotations -}}
+  {{- .Values.storage.annotations | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the Puppet Server conf.d Persistent Volume Claim.
+*/}}
+{{- define "puppetserver.persistence.confd.storageClass" -}}
+{{- if .Values.puppetserver.persistence.confd.storageClass -}}
+  {{- .Values.puppetserver.persistence.confd.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Set mandatory Puppet Server Masters' Service name.
 */}}
 {{- define "puppetserver.puppetserver-masters.serviceName" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -299,6 +299,41 @@ Create the name for the PuppetDB password secret.
 {{- end -}}
 
 {{/*
+Create the name for the PuppetDB Persistent Volume Claim.
+*/}}
+{{- define "puppetdb.persistence.claimName" -}}
+{{- if .Values.puppetdb.persistence.existingClaim -}}
+  {{- .Values.puppetdb.persistence.existingClaim -}}
+{{- else -}}
+  {{ template "puppetdb.fullname" . }}-claim
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the annotations for the PuppetDB Persistent Volume Claim.
+*/}}
+{{- define "puppetdb.persistence.annotations" -}}
+{{- if .Values.puppetdb.persistence.annotations -}}
+  {{- .Values.puppetdb.persistence.annotations | toYaml -}}
+{{- else -}}
+  {{- if .Values.storage.annotations -}}
+    {{- .Values.storage.annotations | toYaml -}}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the storageClassName for the PuppetDB Persistent Volume Claim.
+*/}}
+{{- define "puppetdb.persistence.storageClass" -}}
+{{- if .Values.puppetdb.persistence.storageClass -}}
+  {{- .Values.puppetdb.persistence.storageClass -}}
+{{- else -}}
+  {{- .Values.storage.storageClass -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name for the r10k.code.viaSsh secret.
 */}}
 {{- define "r10k.code.viaSsh.secret" -}}

--- a/templates/puppet-crl-updater-cronjob.yaml
+++ b/templates/puppet-crl-updater-cronjob.yaml
@@ -70,12 +70,8 @@ spec:
             - name: puppet-crl-storage
               emptyDir: {}
             - name: puppet-puppet-storage
-            {{- if .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
-              {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.puppet.config | nindent 14 }}
-            {{- else }}
               persistentVolumeClaim:
-                claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
-            {{- end }}
+                claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
             - name: puppetdb-storage
               persistentVolumeClaim:
                 claimName: {{ template "puppetdb.persistence.claimName" . }}

--- a/templates/puppet-crl-updater-cronjob.yaml
+++ b/templates/puppet-crl-updater-cronjob.yaml
@@ -77,10 +77,6 @@ spec:
                 claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
             {{- end }}
             - name: puppetdb-storage
-            {{- if .Values.puppetdb.customPersistentVolumeClaim.storage.enable }}
-              {{- toYaml .Values.puppetdb.customPersistentVolumeClaim.storage.config | nindent 14 }}
-            {{- else }}
               persistentVolumeClaim:
-                claimName: {{ include "puppetdb.fullname" . }}-claim
-            {{- end }}
+                claimName: {{ template "puppetdb.persistence.claimName" . }}
 {{- end }}

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -369,12 +369,8 @@ spec:
         {{- end }}
         {{- if and ( or .Values.puppetserver.preGeneratedCertsJob.enabled .Values.singleCA.enabled) .Values.puppetdb.enabled}}
         - name: puppetdb-storage
-        {{- if .Values.puppetdb.customPersistentVolumeClaim.storage.enable }}
-          {{- toYaml .Values.puppetdb.customPersistentVolumeClaim.storage.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ include "puppetdb.fullname" . }}-claim
-        {{- end }}
+            claimName: {{ include "puppetdb.persistence.claimName" . }}
         - name: puppetdb-certs
         {{- if not .Values.singleCA.enabled }}
           configMap:

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -297,37 +297,21 @@ spec:
       {{- end }}
       volumes:
         - name: puppet-puppet-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.puppet.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
         {{- if .Values.global.runAsNonRoot }}
         - name: puppet-puppetserver
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-puppetserver-claim
+            claimName: {{ template "puppetserver.persistence.server.claimName" . }}
         - name: puppet-code-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.code.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.code.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-code-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.code.claimName" . }}
         - name: puppet-ca-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.ca.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.ca.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-ca-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.ca.claimName" . }}
         - name: puppet-serverdata-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.serverdata.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.serverdata.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-serverdata-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.data.claimName" . }}
         - name: puppet-docker-entrypoint-config
           configMap:
             name: {{ template "puppetserver.fullname" . }}-docker-entrypoint-config

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -157,12 +157,8 @@ spec:
             {{- toYaml .Values.r10k.containerSecurityContext | nindent 12 }}
       volumes:
         - name: puppet-code-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.code.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.code.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-code-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.code.claimName" . }}
         - name: r10k-code-volume
           configMap:
             name: {{ template "puppetserver.fullname" . }}-r10k-code-config

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -293,12 +293,8 @@ spec:
       {{- end }}
       volumes:
         - name: puppetdb-storage
-        {{- if .Values.puppetdb.customPersistentVolumeClaim.storage.enable }}
-          {{- toYaml .Values.puppetdb.customPersistentVolumeClaim.storage.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ include "puppetdb.fullname" . }}-claim
-        {{- end }}
+            claimName: {{ template "puppetdb.persistence.claimName" . }}
         {{- if .Values.puppetdb.metrics.enabled }}
         - name: puppetdb-metrics-volume
           configMap:

--- a/templates/puppetdb-pvc.yaml
+++ b/templates/puppetdb-pvc.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.puppetdb.enabled }}
-{{- if .Values.puppetdb.customPersistentVolumeClaim.storage.enable }}
-{{- else }}
+{{- if and ( .Values.puppetdb.enabled ) ( not .Values.puppetdb.persistence.existingClaim ) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,24 +10,22 @@ metadata:
     {{- end }}
   annotations:
     {{- if or (.Values.puppetserver.preGeneratedCertsJob.enabled) (.Values.singleCA.enabled) }}
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-weight": "0"
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "0"
     {{- end }}
-    {{- if .Values.storage.annotations }}
-    {{ toYaml .Values.storage.annotations | nindent 4 }}
-    {{- end }}
+    {{- include "puppetdb.persistence.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetdb.persistence.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetdb.persistence.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetdb.persistence.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -71,17 +71,9 @@ spec:
               mountPath: /backup/etc/puppetlabs/puppet/
           volumes:
           - name: puppet-ca-storage
-          {{- if .Values.puppetserver.customPersistentVolumeClaim.ca.enable }}
-            {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.ca.config | nindent 10 }}
-          {{- else }}
             persistentVolumeClaim:
-              claimName: {{ template "puppetserver.fullname" . }}-ca-claim
-          {{- end }}
+              claimName: {{ template "puppetserver.persitence.ca.claimName" . }}
           - name: puppet-puppet-storage
-          {{- if .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
-            {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.puppet.config | nindent 10 }}
-          {{- else }}
             persistentVolumeClaim:
-              claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
-          {{- end }}
+              claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
 {{- end }}

--- a/templates/puppetserver-ca-pvc.yaml
+++ b/templates/puppetserver-ca-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.puppetserver.customPersistentVolumeClaim.ca.enable }}
+{{- if not .Values.puppetserver.persistence.ca.existingClaim }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,20 +12,19 @@ metadata:
     {{- if .Values.global.runAsNonRoot }}
     helm.sh/hook: pre-install
     {{- end }}
-    {{- with .Values.storage.annotations -}}
-    {{ toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "puppetserver.persistence.ca.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetserver.persistence.ca.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetserver.persistence.ca.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetserver.persistence.ca.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/puppetserver-code-pvc.yaml
+++ b/templates/puppetserver-code-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.puppetserver.customPersistentVolumeClaim.code.enable }}
+{{- if not .Values.puppetserver.persistence.code.existingClaim }}
 {{- if or ( eq .Values.puppetserver.compilers.kind "Deployment" ) ( not .Values.puppetserver.compilers.enabled ) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -13,20 +13,19 @@ metadata:
     {{- if .Values.global.runAsNonRoot }}
     helm.sh/hook: pre-install
     {{- end }}
-    {{- with .Values.storage.annotations -}}
-    {{ toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "puppetserver.persistence.code.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetserver.persistence.code.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetserver.persistence.code.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetserver.persistence.code.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/puppetserver-confd-pvc.yaml
+++ b/templates/puppetserver-confd-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.puppetserver.customPersistentVolumeClaim.confd.enable) (not .Values.global.runAsNonRoot) }}
+{{- if and (not .Values.puppetserver.persistence.confd.existingClaim) (not .Values.global.runAsNonRoot) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,20 +12,19 @@ metadata:
     {{- if .Values.global.runAsNonRoot }}
     helm.sh/hook: pre-install
     {{- end }}
-    {{- with .Values.storage.annotations -}}
-    {{ toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "puppetserver.persistence.confd.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetserver.persistence.confd.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetserver.persistence.confd.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetserver.persistence.confd.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/puppetserver-data-pvc.yaml
+++ b/templates/puppetserver-data-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.puppetserver.customPersistentVolumeClaim.serverdata.enable }}
+{{- if not .Values.puppetserver.persistence.data.existingClaim }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,20 +12,19 @@ metadata:
     {{- if .Values.global.runAsNonRoot }}
     helm.sh/hook: pre-install
     {{- end }}
-    {{- with .Values.storage.annotations -}}
-    {{ toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "puppetserver.persistence.data.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetserver.persistence.data.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetserver.persistence.data.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetserver.persistence.data.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -457,26 +457,14 @@ spec:
         fsGroup: 999   # "puppet" GID
       volumes:
         - name: puppet-code-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.code.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.code.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-code-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.code.claimName" . }}
         - name: puppet-puppet-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.puppet.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
         - name: puppet-serverdata-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.serverdata.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.serverdata.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-serverdata-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persitence.data.claimName" . }}
         {{- if .Values.singleCA.enabled }}
         - name: crl-volume
           configMap:
@@ -572,11 +560,11 @@ spec:
         {{- if .Values.global.runAsNonRoot }}
         - name: puppet-puppetserver
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-puppetserver-claim
+            claimName: {{ template "puppetserver.persistence.server.claimName" . }}
         {{- else }}
         - name: puppet-confd
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-confd-claim
+            claimName: {{ template "puppetserver.persistence.confd.claimName" . }}
         {{- end }}
         {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
         - name: {{ $extraSecret.name }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -486,39 +486,23 @@ spec:
       volumes:
         {{- if (not .Values.puppetserver.compilers.enabled) }}
         - name: puppet-code-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.code.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.code.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-code-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.code.claimName" . }}
         {{- end }}
         - name: puppet-ca-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.ca.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.ca.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-ca-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.ca.claimName" . }}
         - name: puppet-puppet-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.puppet.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-puppet-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
         {{- if .Values.singleCA.enabled }}
         - name: crl-volume
           configMap:
             name: {{ template "puppetserver.fullname" . }}-crl-config
         {{- end }}
         - name: puppet-serverdata-storage
-        {{- if .Values.puppetserver.customPersistentVolumeClaim.serverdata.enable }}
-          {{- toYaml .Values.puppetserver.customPersistentVolumeClaim.serverdata.config | nindent 10 }}
-        {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-serverdata-claim
-        {{- end }}
+            claimName: {{ template "puppetserver.persistence.data.claimName" . }}
         {{- if .Values.puppetserver.masters.multiMasters.enabled }}
         - name: init-masters-volume
           configMap:
@@ -617,11 +601,11 @@ spec:
         {{- if .Values.global.runAsNonRoot }}
         - name: puppet-puppetserver
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-puppetserver-claim
+            claimName: {{ template "puppetserver.persistence.server.claimName" . }}
         {{- else }}
         - name: puppet-confd
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.fullname" . }}-confd-claim
+            claimName: {{ template "puppetserver.persistence.confd.claimName" . }}
         {{- end }}
         {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
         - name: {{ $extraSecret.name }}

--- a/templates/puppetserver-puppetserver-pvc.yaml
+++ b/templates/puppetserver-puppetserver-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.puppetserver.customPersistentVolumeClaim.puppetserver.enable) .Values.global.runAsNonRoot }}
+{{- if and (not .Values.puppetserver.persistence.server.existingClaim) .Values.global.runAsNonRoot }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,20 +12,19 @@ metadata:
     {{- if .Values.global.runAsNonRoot }}
     helm.sh/hook: pre-install
     {{- end }}
-    {{- with .Values.storage.annotations -}}
-    {{ toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "puppetserver.persistence.server.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetserver.persistence.server.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetserver.persistence.server.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetserver.persistence.server.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/puppetserver-pvc.yaml
+++ b/templates/puppetserver-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.puppetserver.customPersistentVolumeClaim.puppet.enable }}
+{{- if not .Values.puppetserver.persistence.puppet.existingClaim }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,20 +12,19 @@ metadata:
     {{- if or .Values.puppetserver.preGeneratedCertsJob.enabled .Values.singleCA.enabled .Values.global.runAsNonRoot }}
     helm.sh/hook: pre-install
     {{- end }}
-    {{- if .Values.storage.annotations }}
-    {{ toYaml .Values.storage.annotations | nindent 4 }}
-    {{- end }}
+    {{- include "puppetserver.persistence.puppet.annotations" . | nindent 4 }}
 spec:
   accessModes:
-    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+    {{- toYaml ( .Values.puppetserver.persistence.puppet.accessModes | default .Values.storage.accessModes ) | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.storage.size | quote }}
-  {{- if .Values.storage.storageClass }}
-  {{- if (eq "-" .Values.storage.storageClass) }}
+      storage: {{ .Values.puppetserver.persistence.puppet.size | default .Values.storage.size | quote }}
+  {{- $storageClass := include "puppetserver.persistence.puppet.storageClass" . }}
+  {{- if $storageClass }}
+  {{- if (eq "-" $storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.storage.storageClass }}"
+  storageClassName: "{{ $storageClass }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -534,40 +534,38 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: puppet-code-volume
-      {{- if .Values.storage.annotations }}
-      annotations:
-        {{- toYaml .Values.storage.annotations | nindent 10 }}
-      {{- end }}
+        annotations:
+          {{- include "puppetserver.persistence.code.annotations" . | nindent 10 }}
       spec:
         accessModes:
-          {{- toYaml .Values.storage.accessModes | nindent 10 }}
+          {{- toYaml ( .Values.puppetserver.persistence.code.accessModes | default .Values.storage.accessModes ) | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.storage.size }}"
-        {{- if .Values.storage.storageClass }}
-        {{- if (eq "-" .Values.storage.storageClass) }}
+            storage: {{ .Values.puppetserver.persistence.code.size | default .Values.storage.size | quote }}
+        {{- $storageClass := include "puppetserver.persistence.code.storageClass" . }}
+        {{- if $storageClass }}
+        {{- if (eq "-" $storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: "{{ .Values.storage.storageClass }}"
+        storageClassName: "{{ $storageClass }}"
         {{- end }}
         {{- end }}
     - metadata:
         name: puppet-puppet-volume
-      {{- if .Values.storage.annotations }}
-      annotations:
-        {{- toYaml .Values.storage.annotations | nindent 10 }}
-      {{- end }}
+        annotations:
+          {{- include "puppetserver.persistence.puppet.annotations" . | nindent 10 }}
       spec:
         accessModes:
-          {{- toYaml .Values.storage.accessModes | nindent 10 }}
+          {{- toYaml ( .Values.puppetserver.persistence.puppet.accessModes | default .Values.storage.accessModes ) | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.storage.size }}"
-        {{- if .Values.storage.storageClass }}
-        {{- if (eq "-" .Values.storage.storageClass) }}
+        {{- $storageClass := include "puppetserver.persistence.puppet.storageClass" . }}
+        {{- if $storageClass }}
+        {{- if (eq "-" $storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: "{{ .Values.storage.storageClass }}"
+        storageClassName: "{{ $storageClass }}"
         {{- end }}
         {{- end }}
 {{- end }}

--- a/tests/puppetserver-code-pvc_test.yaml
+++ b/tests/puppetserver-code-pvc_test.yaml
@@ -5,9 +5,9 @@ release:
   name: puppetserver
   namespace: puppet
 tests:
-  - it: should not create the volume if "customPersistentVolumeClaim.code.enable" is true
+  - it: should not create the volume if "puppetserver.persistence.code.claimName" is non-empty
     set:
-      puppetserver.customPersistentVolumeClaim.code.enable: true
+      puppetserver.persistence.code.claimName: dummy
     asserts:
       - hasDocuments:
           count: 0

--- a/tests/puppetserver-data-pvc_test.yaml
+++ b/tests/puppetserver-data-pvc_test.yaml
@@ -5,9 +5,9 @@ release:
   name: puppetserver
   namespace: puppet
 tests:
-  - it: should not create the volume if "customPersistentVolumeClaim.serverdata.enable" is true
+  - it: should not create the volume if "puppetserver.persistence.data.claimName" is non-empty
     set:
-      puppetserver.customPersistentVolumeClaim.serverdata.enable: true
+      puppetserver.persistence.data.claimName: dummy
     asserts:
       - hasDocuments:
           count: 0

--- a/tests/puppetserver-pvc_test.yaml
+++ b/tests/puppetserver-pvc_test.yaml
@@ -5,9 +5,9 @@ release:
   name: puppetserver
   namespace: puppet
 tests:
-  - it: should not create the volume if "customPersistentVolumeClaim.puppet.enable" is true
+  - it: should not create the volume if "puppetserver.persistence.puppet.claimName" is non-empty
     set:
-      puppetserver.customPersistentVolumeClaim.puppet.enable: true
+      puppetserver.persistence.puppet.claimName: dummy
     asserts:
       - hasDocuments:
           count: 0

--- a/values.yaml
+++ b/values.yaml
@@ -58,30 +58,121 @@ puppetserver:
   tag: 7.9.2
   pullPolicy: IfNotPresent
 
-  ## Use custom PVC for the Puppet Server Master
-  customPersistentVolumeClaim:
-    serverdata:
-      enable: false
-      config: {}
-    #  azureDisk:
-    #    kind: Managed
-    #    diskName: myAKSDisk
-    #    diskURI: /subscriptions/<subscriptionID>/resourceGroups/MC_myAKSCluster_myAKSCluster_eastus/providers/Microsoft.Compute/disks/myAKSDisk
-    puppet:
-      enable: false
-      config: {}
-    code:
-      enable: false
-      config: {}
+  ## Configure persistence for Puppet Server
+  persistence:
     ca:
-      enable: false
-      config: {}
+      ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+      ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+      existingClaim: ''
+      ## Persistent Volume Access Modes
+      ## Be sure your chosen Storage Class below allows this Access Mode
+      ## If not specified storage.accessModes is taken.
+      accessModes: []
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+      storageClass: ""
+      ## Persistent Volume annotations
+      ## If not specified storage.annotations is taken.
+      annotations: {}
+      ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+      size: ""
+
+    code:
+      ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+      ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+      existingClaim: ''
+      ## Persistent Volume Access Modes
+      ## Be sure your chosen Storage Class below allows this Access Mode
+      ## If not specified storage.accessModes is taken.
+      accessModes: []
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+      storageClass: ""
+      ## Persistent Volume annotations
+      ## If not specified storage.annotations is taken.
+      annotations: {}
+      ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+      size: ""
+
+    data:
+      ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+      ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+      existingClaim: ''
+      ## Persistent Volume Access Modes
+      ## Be sure your chosen Storage Class below allows this Access Mode
+      ## If not specified storage.accessModes is taken.
+      accessModes: []
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+      storageClass: ""
+      ## Persistent Volume annotations
+      ## If not specified storage.annotations is taken.
+      annotations: {}
+      ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+      size: ""
+
     confd:
-      enable: false
-      config: {}
-    puppetserver:
-      enable: false
-      config: {}
+      ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+      ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+      existingClaim: ''
+      ## Persistent Volume Access Modes
+      ## Be sure your chosen Storage Class below allows this Access Mode
+      ## If not specified storage.accessModes is taken.
+      accessModes: []
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+      storageClass: ""
+      ## Persistent Volume annotations
+      ## If not specified storage.annotations is taken.
+      annotations: {}
+      ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+      size: ""
+
+    puppet:
+      ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+      ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+      existingClaim: ''
+      ## Persistent Volume Access Modes
+      ## Be sure your chosen Storage Class below allows this Access Mode
+      ## If not specified storage.accessModes is taken.
+      accessModes: []
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+      storageClass: ""
+      ## Persistent Volume annotations
+      ## If not specified storage.annotations is taken.
+      annotations: {}
+      ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+      size: ""
+
+    server:
+      ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+      ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+      existingClaim: ''
+      ## Persistent Volume Access Modes
+      ## Be sure your chosen Storage Class below allows this Access Mode
+      ## If not specified storage.accessModes is taken.
+      accessModes: []
+      ## Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+      storageClass: ""
+      ## Persistent Volume annotations
+      ## If not specified storage.annotations is taken.
+      annotations: {}
+      ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+      size: ""
 
   ## Mandatory Deployment of Puppet Server Master/s
   ##

--- a/values.yaml
+++ b/values.yaml
@@ -688,11 +688,27 @@ puppetdb:
   ## puppetdb metrics enable/disable flag
   metrics:
     enabled: false
-  ## Use custom PVC for the Puppet PuppetDB
-  customPersistentVolumeClaim:
-    storage:
-      enable: false
-      config: {}
+
+  ## Configure persistence for PuppetDB
+  persistence:
+    ## If an existing Persistent Volume Claim needs to be used, specify the name here.
+    ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
+    existingClaim: ''
+
+    ## PuppetDB data Persistent Volume Access Modes
+    ## Be sure your chosen Storage Class below allows this Access Mode
+    ## If not specified storage.accessModes is taken.
+    accessModes: []
+    ## PuppetDB data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If not specified storage.storageClass is taken. See the documentation of storage.storageClass for more details.
+    storageClass: ""
+    ## Puppetserver data Persistent Volume annotations
+    ## If not specified storage.annotations is taken.
+    annotations: {}
+    ## Size request of the Persistent Volume Claim, of not specified storage.storageClass is taken.
+    size: ""
 
   ## Optional configure serviceAccount & rbac
   serviceAccount:


### PR DESCRIPTION
Having a big codebase for puppet is very common.
In its previous form this chart forced all Persistent Volume Claims to have the same size (which is very expensive), or to manually create the Persistent Volume Claim for the puppet codebase.

With this change it is possible to select size, storageClass, annotations, etc, for every PersistentVolumeClaim individually.

This can be useful for use-cases like backup of some PVCs but not all, setting different sizes, using ReadWriteMany for puppetCA but ReadWriteOnce and StatefulSet for the compilers, etc.

This is a breaking change since it completely remove the old logic of external PVC handling and creates a new one where the PVC is only named and nothing else is to be done.

The version bump is to be determined (8.0 ?).