### PR TITLE
feat(r10k): parametrize the command line for r10k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v8.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.0) (2023-07-12)
+- Feat: allows parametrized r10k code entrypoints
+
 ## [v7.4.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.5) (2023-06-28)
 - Fix: r10k pod needs a script to run. Added all the needed mountpoint
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.0.0
+version: 8.1.0
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.tag` | r10k img tag | `3.15.2`|
 | `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`|
 | `r10k.code.resources` | r10k control repo resource limits |``|
+| `r10k.code.command` | r10k entrypoint command | [`/bin/sh`,`-c`]|
+| `r10k.code.args` | r10k entrypoint command argument |[`/etc/puppetlabs/puppet/r10k_code_entrypoint.sh;`]|
+| `r10k.code.readinessProbe` | r10k entrypoint |[`/bin/sh`, `-ec`, `test -f {{ .Values.r10k.code.cronJob.successFile }}`] |
 | `r10k.code.cronJob.enabled` | enable or disable r10k control repo cron job schedule policy | `true`|
 | `r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`|
 | `r10k.code.cronJob.splay` | apply random sleep before running r10k control repo cron job | `true`|

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -39,10 +39,13 @@ spec:
           image: "{{ tpl .Values.r10k.image . }}:{{ tpl .Values.r10k.tag . }}"
           imagePullPolicy: {{ tpl .Values.r10k.imagePullPolicy . }}
           command:
-            - /bin/sh
-            - -c
+            {{- range .Values.r10k.code.command }}
+            - {{ . | quote }}
+            {{- end}}
           args:
-            - /etc/puppetlabs/puppet/r10k_code_entrypoint.sh;
+            {{- range .Values.r10k.code.args }}
+            - {{ . | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.r10k.code.resources | nindent 12 }}
           env:
@@ -81,7 +84,10 @@ spec:
             subPath: r10k_code.yaml
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.code.cronJob.successFile }}"]
+              command:
+              {{- range .values.r10k.code.readinessprobe }}
+              - {{ . | quote }}
+              {{- end}}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20
@@ -89,6 +95,7 @@ spec:
             timeoutSeconds: 5
           securityContext:
             {{- toYaml .Values.r10k.containerSecurityContext | nindent 12 }}
+        {{- if (include "hiera.enable" .) }}
         - name: r10k-hiera
           image: "{{ tpl .Values.r10k.image . }}:{{ tpl .Values.r10k.tag . }}"
           imagePullPolicy: {{ tpl .Values.r10k.imagePullPolicy . }}
@@ -155,6 +162,7 @@ spec:
             timeoutSeconds: 5
           securityContext:
             {{- toYaml .Values.r10k.containerSecurityContext | nindent 12 }}
+        {{- end }}
       volumes:
         - name: puppet-code-storage
           persistentVolumeClaim:

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -312,7 +312,14 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
-          command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_code_entrypoint.sh" ]
+          command:
+            {{- range .Values.r10k.code.command }}
+            - {{ . | quote }}
+            {{- end}}
+          args:
+            {{- range .Values.r10k.code.args }}
+            - {{ . | quote }}
+            {{- end }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
             runAsGroup: {{ .Values.global.securityContext.runAsGroup }}
@@ -336,9 +343,13 @@ spec:
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-storage
             mountPath: /etc/puppetlabs/puppet/
+
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.code.cronJob.successFile }}"]
+              command:
+              {{- range .values.r10k.code.readinessprobe }}
+              - {{ . | quote }}
+              {{- end}}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20
@@ -386,7 +397,7 @@ spec:
           - name: puppet-puppet-storage
             mountPath: /etc/puppetlabs/puppet/
           readinessProbe:
-            exec:
+            exec: 
               command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.hiera.cronJob.successFile }}"]
             failureThreshold: 2
             initialDelaySeconds: 5

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -331,7 +331,14 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
-          command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_code_entrypoint.sh" ]
+          command:
+            {{- range .Values.r10k.code.command }}
+            - {{ . | quote }}
+            {{- end}}
+          args:
+            {{- range .Values.r10k.code.args }}
+            - {{ . | quote }}
+            {{- end }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
             runAsGroup: {{ .Values.global.securityContext.runAsGroup }}
@@ -366,7 +373,10 @@ spec:
             subPath: r10k_code.yaml
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.code.cronJob.successFile }}"]
+              command:
+              {{- range .Values.r10k.code.readinessProbe }}
+              - {{ . | quote }}
+              {{- end}}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -282,7 +282,14 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
-          command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_code_entrypoint.sh" ]
+          command:
+            {{- range .Values.r10k.code.command }}
+            - {{ . | quote }}
+            {{- end}}
+          args:
+            {{- range .Values.r10k.code.args }}
+            - {{ . | quote }}
+            {{- end }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
             runAsGroup: {{ .Values.global.securityContext.runAsGroup }}

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,6 @@ global:
     image: puppet/r10k
     tag: 3.15.2
     imagePullPolicy: IfNotPresent
-
   pgchecker:
     image: docker.io/busybox
     tag: 1.36
@@ -603,6 +602,13 @@ r10k:
     #  limits:
     #    memory: 512Mi
     #    cpu: 300m
+    command:
+      - "/bin/sh"
+      - "-c"
+    args:
+      - /etc/puppetlabs/puppet/r10k_code_entrypoint.sh;
+    readinessProbe:
+      ["/bin/sh", "-ec", "test -f {{ .Values.r10k.code.cronJob.successFile }}"]
     cronJob:
       enabled: true
       schedule: "*/5 * * * *"


### PR DESCRIPTION
# What:
Allows the parametrization of the command line for the r10k pods.

# Why:
This allows a "manual" launch of the r10k command, usefull for exemple for a CI.

# How:
Simply add parameters instead of the hard-coded r10k command. 
As it is going now in the values file, this is not a breaking change and default values are kept.
 
