### PR TITLE
R10k non-sidecar deployment fixes

### DIFF
--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -170,12 +170,12 @@ spec:
         - name: r10k-code-volume
           configMap:
             name: {{ template "puppetserver.fullname" . }}-r10k-code-config
-            defaultMode: 0550
+            defaultMode: 0777
         {{- if or (.Values.r10k.code.viaSsh.credentials.existingSecret) (and (.Values.r10k.code.viaSsh.credentials.ssh.value) (.Values.r10k.code.viaSsh.credentials.known_hosts.value)) }}
         - name: r10k-code-ssh
           secret:
             secretName: {{ template "r10k.code.viaSsh.secret" . }}
-            defaultMode: 288 # = mode 0440
+            defaultMode: 292 # = mode 0440
             items:
               - key: id_rsa
                 path: id_rsa

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              {{- range .values.r10k.code.readinessProbe }}
+              {{- range .Values.r10k.code.readinessProbe }}
               - {{ . | quote }}
               {{- end}}
             failureThreshold: 2


### PR DESCRIPTION
This resolves an r10k issue when trying to deploy not as a sidecar container. The Values variable name is lowercase, causing compile issues.