### PR TITLE
Fix (#186): wrong init value of r10k-code deployment readinessprobe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)
+- Fix: Wrong init value of r10k-code deployment readinessprobe
+
 ## [v8.1.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.2) (2023-08-16)
 - Feat: allow parametrize readiness probe scheme
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.2
+version: 8.1.3
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -374,9 +374,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              {{- range .Values.r10k.code.readinessProbe }}
-              - {{ . | quote }}
-              {{- end}}
+              {{- include "r10k.code.readinessProbe" .  | nindent 16 }}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20


### PR DESCRIPTION
This fix #186 

Since we defined [`r10k.code.readinessProbe`](https://github.com/puppetlabs/puppetserver-helm-chart/blob/master/templates/_helpers.tpl#L197) in _helpers.tpl, 

I think we should use this variable instead of `.Values.r10k.code.readinessProbe` in r10k-code deployment's readinessProbe to avoid an empty string generate
(which might caused the r10k-code pods always in unhealthy if user doesn't define `.Values.r10k.code.readinessProbe` in their values.yaml)

Thanks.