### PR TITLE
Use up-to-date containers for puppetserver/puppetdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-17)
+- Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
+
 ## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)
 - Fix: Wrong init value of r10k-code deployment readinessprobe
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.3
-appVersion: 7.9.2
+version: 8.1.4
+appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `global.r10k.imagePullPolicy`| r10k image pull policy |`IfNotPresent`|
 | `global.extraEnv.*`| add extra environment variables to all containers |``|
 | `puppetserver.name` | puppetserver component label | `puppetserver`|
-| `puppetserver.image` | puppetserver image | `puppet/puppetserver`|
-| `puppetserver.tag` | puppetserver img tag | `6.12.1`|
+| `puppetserver.image` | puppetserver image | `voxpupuli/container-puppetserver`|
+| `puppetserver.tag` | puppetserver img tag | `7.13.0`|
 | `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
 | `puppetserver.persistence.data.existingClaim`| If non-empty, use a pre-defined PVC for puppet data |``|
 | `puppetserver.persistence.data.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
@@ -392,8 +392,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `postgresql.networkPolicy.enabled` | enable `networkPolicy` on  postgresql | `true`|
 | `puppetdb.enabled` | puppetdb component enabled |`true`|
 | `puppetdb.name` | puppetdb component label | `puppetdb`|
-| `puppetdb.image` | puppetdb img | `davidphay/puppetdb`|
-| `puppetdb.tag` | puppetdb img tag | `7.12.1`|
+| `puppetdb.image` | puppetdb img | `voxpupuli/container-puppetdb`|
+| `puppetdb.tag` | puppetdb img tag | `7.14.0`|
 | `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`|
 | `puppetdb.resources` | puppetdb resource limits |``|
 | `puppetdb.extraEnv` | puppetdb additional container env vars |``|

--- a/README.md
+++ b/README.md
@@ -577,3 +577,4 @@ kill %[job_numbers_above]
 * [Ben Feld](https://github.com/rootshellz), Contributor
 * [Julien Godin](https://github.com/JGodin-C2C), Contributor
 * [Diego Abelenda](https://github.com/dabelenda), Contributor
+* [Linas Daneliukas](https://github.com/ldaneliukas), Contributor

--- a/values.yaml
+++ b/values.yaml
@@ -54,8 +54,8 @@ global:
 ##
 puppetserver:
   name: puppetserver
-  image: puppet/puppetserver
-  tag: 7.9.2
+  image: voxpupuli/container-puppetserver
+  tag: 7.13.0
   pullPolicy: IfNotPresent
 
   ## Configure persistence for Puppet Server
@@ -706,8 +706,8 @@ r10k:
 puppetdb:
   enabled: true
   name: puppetdb
-  image: davidphay/puppetdb
-  tag: 7.12.1
+  image: voxpupuli/container-puppetdb
+  tag: 7.14.0
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:


### PR DESCRIPTION
Fixes #179 

Tested both Puppetserver/PuppetDB 7 and Puppetserver/PuppetDB 8 in a production environment.