### PR TITLE
Add ability to populate env from secret & various bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
-## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-17)
+## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-20)
 - Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
+- Feat: Environment variables from secrets
 
 ## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)
 - Fix: Wrong init value of r10k-code deployment readinessprobe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 
 ## [v8.1.6](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.6) (2023-11-27)
 - Fix: Typo in compiler statefulset readiness probe scheme
-- Fix: Add a baseline `PUPPETDB_JAVA_ARGS` which includes `-Xlog:gc:` instead of the default deprecated `-Xloggc` and an existing log path
-- Feat: Environment variables from secrets
+- Fix: `PUPPETDB_JAVA_ARGS` which includes `-Xlog:gc:` instead of the deprecated `-Xloggc` and uses an existing path
+- Fix: Broken r10k-code command for statefulset compilers & standardize r10k-code readiness probe usage
+- Feat: Environment variables loaded from secret key-value pairs
 
 ## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)
 - Fix: Typo in the restic backup template preventing chart from being deployed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
-## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-20)
-- Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
+## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)
 - Feat: Environment variables from secrets
+
+## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-17)
+- Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
 
 ## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)
 - Fix: Wrong init value of r10k-code deployment readinessprobe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v8.1.6](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.6) (2023-11-27)
+## [v8.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.2.0) (2023-11-27)
 - Fix: Typo in compiler statefulset readiness probe scheme
 - Fix: `PUPPETDB_JAVA_ARGS` which includes `-Xlog:gc:` instead of the deprecated `-Xloggc` and uses an existing path
 - Fix: Broken r10k-code command for statefulset compilers & standardize r10k-code readiness probe usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 
 ## [v8.1.6](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.6) (2023-11-27)
 - Fix: Typo in compiler statefulset readiness probe scheme
+- Fix: Add a baseline `PUPPETDB_JAVA_ARGS` which includes `-Xlog:gc:` instead of the default deprecated `-Xloggc` and an existing log path
 - Feat: Environment variables from secrets
 
 ## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # This repository is owned by community partners
 
-* @Xtigyro @slconley @raphink @davidphay @skoef @nielshojen
+* @Xtigyro @slconley @raphink @davidphay @skoef @nielshojen @ldaneliukas

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.5
+version: 8.1.6
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.6
+version: 8.2.0
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.4
+version: 8.1.5
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -30,6 +30,8 @@ maintainers:
     email: reinier@skoef.nl
   - name: nielshojen
     email: niels@hojen.net
+  - name: ldaneliukas
+    email: linas@daneliukas.eu
   - name: Pupperware Team
     email: pupperware@puppet.com
 engine: gotpl

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `global.r10k.tag` | r10k img tag | `3.15.2`|
 | `global.r10k.imagePullPolicy`| r10k image pull policy |`IfNotPresent`|
 | `global.extraEnv.*`| add extra environment variables to all containers |``|
+| `global.extraEnvSecret`| add extra environment variables to all containers from pre-existing secret |``|
 | `puppetserver.name` | puppetserver component label | `puppetserver`|
 | `puppetserver.image` | puppetserver image | `voxpupuli/container-puppetserver`|
 | `puppetserver.tag` | puppetserver img tag | `7.13.0`|
@@ -246,6 +247,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.masters.networkPolicy.additionnalIngressRules` | puppetserver masters resource limits | `allow 8140 from everywhere` |
 | `puppetserver.masters.extraContainers`| Extra containers to inject into the master pod |``|
 | `puppetserver.masters.extraEnv` | puppetserver masters additional container env vars |``|
+| `puppetserver.masters.extraEnvSecret` | puppetserver masters additional container env vars from pre-existing secret |``|
 | `puppetserver.masters.extraLabels` | puppetserver masters additional labels |``|
 | `puppetserver.masters.updateStrategy` | puppetserver masters update strategy |`RollingUpdate`|
 | `puppetserver.masters.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
@@ -303,6 +305,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.compilers.annotations`| puppetserver compilers statefulset annotations |``|
 | `puppetserver.compilers.extraContainers`| Extra containers to inject into the compiler pod |``|
 | `puppetserver.compilers.extraEnv` | puppetserver compilers additional container env vars |``|
+| `puppetserver.compilers.extraEnvSecret` | puppetserver compilers additional container env vars from pre-existing secret |``|
 | `puppetserver.compilers.extraLabels` | puppetserver compilers additional labels |``|
 | `puppetserver.compilers.updateStrategy` | puppetserver compilers update strategy |`RollingUpdate`|
 | `puppetserver.compilers.readinessProbeInitialDelay` | the initial delay for the puppetserver masters readiness probe | `180`|
@@ -367,6 +370,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.code.defaultRepoExtraConf` | yaml to be added to the default repo in r10k_code.yaml |``|
 | `r10k.code.extraArgs` | r10k control repo additional container env args |``|
 | `r10k.code.extraEnv` | r10k control repo additional container env vars |``|
+| `r10k.code.extraEnvSecret` | r10k control repo additional container env vars from pre-existing secret |``|
 | `r10k.code.viaSsh.credentials.ssh.value`| r10k control repo ssh key file |``|
 | `r10k.code.viaSsh.credentials.known_hosts.value`| r10k control repo ssh known hosts file |``|
 | `r10k.code.viaSsh.credentials.existingSecret`| r10k control repo ssh secret that holds ssh key and known hosts files |``|
@@ -380,6 +384,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.hiera.defaultRepoExtraConf` | yaml to be added to the default repo in r10k_hiera.yaml |``|
 | `r10k.hiera.extraArgs` | r10k hiera data additional container env args |``|
 | `r10k.hiera.extraEnv` | r10k hiera data additional container env vars |``|
+| `r10k.hiera.extraEnvSecret` | r10k hiera data additional container env vars from pre-existing secret |``|
 | `r10k.hiera.viaSsh.credentials.ssh.value`| r10k hiera data ssh key file |``|
 | `r10k.hiera.viaSsh.credentials.known_hosts.value`| r10k hiera data ssh known hosts file |``|
 | `r10k.hiera.viaSsh.credentials.existingSecret`| r10k hiera data ssh secret that holds ssh key and known hosts files |``|
@@ -397,6 +402,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`|
 | `puppetdb.resources` | puppetdb resource limits |``|
 | `puppetdb.extraEnv` | puppetdb additional container env vars |``|
+| `puppetdb.extraEnvSecret` | puppetdb additional container env vars from pre-existing secret |``|
 | `puppetdb.extraLabels` | puppetdb additional labels |``|
 | `puppetdb.service.type` | define `spec.type` for the puppetdb service |`ClusterIP`|
 | `puppetdb.service.annotations` | puppetdb service annotations |``|
@@ -426,6 +432,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetboard.pullPolicy` | puppetboard img pull policy | `IfNotPresent`|
 | `puppetboard.resources` | puppetboard resource limits |``|
 | `puppetboard.extraEnv` | puppetboard additional container env vars |``|
+| `puppetboard.extraEnvSecret` | puppetboard additional container env vars from pre-existing secret |``|
 | `puppetboard.service.targetPort` | target port for the puppetboard service port |`puppetboard`|
 | `puppetboard.ingress.enabled`| puppetboard ingress creation enabled |`false`|
 | `puppetboard.ingress.annotations`| puppetboard ingress annotations |``|
@@ -450,6 +457,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `singleCA.enabled`| Enable single CA |`false`|
 | `singleCA.crl.cronJob.schedule`| crl cron job schedule policy |`* 0 * * * *`|
 | `singleCA.crl.extraEnv`| crl additional container env vars |``|
+| `singleCA.crl.extraEnvSecret`| crl additional container env vars from pre-existing secret |``|
 | `singleCA.crl.resources`| crl container resource limits |``|
 | `singleCA.crl.config`| override the default crl script to retrieve the crl.pem |`see values.yaml`|
 | `singleCA.crl.url`| set the url where crl.pem is located (MANDATORY) |``|
@@ -471,6 +479,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `metrics.prometheus.port` | puppetdb exporter svc exposed ports | `9635` |
 | `metrics.prometheus.resources` | puppetdb exporter container resource limits | `` |
 | `metrics.prometheus.extraEnv` | puppetdb exporter additional container env vars | `` |
+| `metrics.prometheus.extraEnvSecret` | puppetdb exporter additional container env vars from pre-existing secret | `` |
 | `metrics.prometheus.metricRelabelings` | relabel prometheus metrics | `` |
 | `metrics.prometheus.relabelings` | rewrite the label set of a target before it gets scraped | `` |
 | `metrics.prometheus.jobLabel` | The label to use to retrieve the job name from. | `puppetdb` |

--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ kill %[job_numbers_above]
 * [Reinier Schoof](https://github.com/skoef), Maintainer
 * [Niels Højen](https://github.com/nielshojen), Maintainer
 * [Scott Cressi](https://www.linkedin.com/in/scottcressi/), Co-Author
+* [Linas Daneliukas](https://github.com/ldaneliukas), Maintainer
 * [Kai Sisterhenn](https://www.sistason.de/), Contributor
 * [chwehrli](https://github.com/chwehrli), Contributor
 * [Hryhorii Didenko](https://github.com/HryhoriiDidenko), Contributor
@@ -587,4 +588,3 @@ kill %[job_numbers_above]
 * [Ben Feld](https://github.com/rootshellz), Contributor
 * [Julien Godin](https://github.com/JGodin-C2C), Contributor
 * [Diego Abelenda](https://github.com/dabelenda), Contributor
-* [Linas Daneliukas](https://github.com/ldaneliukas), Contributor

--- a/templates/puppet-crl-updater-cronjob.yaml
+++ b/templates/puppet-crl-updater-cronjob.yaml
@@ -52,11 +52,11 @@ spec:
               envFrom:
               {{- if .Values.global.extraEnvSecret }}
                 - secretRef:
-                  name: {{ .Values.global.extraEnvSecret }}
+                    name: {{ .Values.global.extraEnvSecret }}
               {{- end }}
               {{- if .Values.singleCA.crl.extraEnvSecret }}
                 - secretRef:
-                  name: {{ .Values.singleCA.crl.extraEnvSecret }}
+                    name: {{ .Values.singleCA.crl.extraEnvSecret }}
               {{- end }}
               volumeMounts:
                 - name: crl-volume

--- a/templates/puppet-crl-updater-cronjob.yaml
+++ b/templates/puppet-crl-updater-cronjob.yaml
@@ -49,6 +49,15 @@ spec:
                 - name: {{ $key }}
                   value: "{{ $value }}"
                 {{- end }}
+              envFrom:
+              {{- if .Values.global.extraEnvSecret }}
+                - secretRef:
+                  name: {{ .Values.global.extraEnvSecret }}
+              {{- end }}
+              {{- if .Values.singleCA.crl.extraEnvSecret }}
+                - secretRef:
+                  name: {{ .Values.singleCA.crl.extraEnvSecret }}
+              {{- end }}
               volumeMounts:
                 - name: crl-volume
                   mountPath: /tmp/crl

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -42,6 +42,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.masters.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+          {{- end }}
           command: [ "sh", "-c" ]
           args:
             - echo "create folder";
@@ -140,6 +149,11 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
           volumeMounts:
             - name: puppetserver-certs
               mountPath: /tmp/puppetserver
@@ -191,6 +205,11 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
           volumeMounts:
             - name: puppetdb-certs
               mountPath: /tmp/puppetdb
@@ -241,6 +260,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.masters.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+          {{- end }}
           ports:
             - containerPort: {{ template "puppetserver.puppetserver-masters.port" .}}
           volumeMounts:

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -45,11 +45,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-                name: {{ .Values.global.extraEnvSecret }}
+              name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:
-                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c" ]
           args:
@@ -152,7 +152,7 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-                name: {{ .Values.global.extraEnvSecret }}
+              name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           volumeMounts:
             - name: puppetserver-certs
@@ -208,7 +208,7 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-                name: {{ .Values.global.extraEnvSecret }}
+              name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           volumeMounts:
             - name: puppetdb-certs
@@ -263,7 +263,7 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-                name: {{ .Values.global.extraEnvSecret }}
+              name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -45,11 +45,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c" ]
           args:
@@ -152,7 +152,7 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           volumeMounts:
             - name: puppetserver-certs
@@ -208,7 +208,7 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           volumeMounts:
             - name: puppetdb-certs
@@ -263,7 +263,7 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -94,9 +94,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              {{- range .values.r10k.code.readinessProbe }}
-              - {{ . | quote }}
-              {{- end}}
+              {{- include "r10k.code.readinessProbe" .  | nindent 16 }}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -57,6 +57,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.code.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.code.extraEnvSecret }}
+          {{- end }}
           volumeMounts:
           {{- with .Values.r10k.code.viaSsh.credentials }}
           {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
@@ -115,6 +124,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.hiera.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+          {{- end }}
           volumeMounts:
             {{- with .Values.r10k.hiera.viaSsh.credentials }}
             {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -60,11 +60,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.code.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.code.extraEnvSecret }}
+                name: {{ .Values.r10k.code.extraEnvSecret }}
           {{- end }}
           volumeMounts:
           {{- with .Values.r10k.code.viaSsh.credentials }}
@@ -127,11 +127,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.hiera.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+                name: {{ .Values.r10k.hiera.extraEnvSecret }}
           {{- end }}
           volumeMounts:
             {{- with .Values.r10k.hiera.viaSsh.credentials }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -127,6 +127,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetdb.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetdb.extraEnvSecret }}
+          {{- end }}
           ports:
             - name: pdb-http
               containerPort: 8080
@@ -182,6 +191,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetboard.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetboard.extraEnvSecret }}
+          {{- end }}
           ports:
             - name: puppetboard
               containerPort: {{ .Values.puppetboard.port }}
@@ -216,6 +234,19 @@ spec:
           {{- range $key, $value := .Values.puppetdb.extraEnv }}
           - name: {{ $key }}
             value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.singleCA.crl.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.singleCA.crl.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetdb.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetdb.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/opt/puppetlabs/server/data/puppetdb/scripts/crl_entrypoint.sh" ]
           securityContext:
@@ -261,6 +292,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.metrics.prometheus.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.metrics.prometheus.extraEnvSecret }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.prometheus.port }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -130,11 +130,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetdb.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetdb.extraEnvSecret }}
+                name: {{ .Values.puppetdb.extraEnvSecret }}
           {{- end }}
           ports:
             - name: pdb-http
@@ -194,11 +194,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetboard.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetboard.extraEnvSecret }}
+                name: {{ .Values.puppetboard.extraEnvSecret }}
           {{- end }}
           ports:
             - name: puppetboard
@@ -238,15 +238,15 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.singleCA.crl.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.singleCA.crl.extraEnvSecret }}
+                name: {{ .Values.singleCA.crl.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetdb.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetdb.extraEnvSecret }}
+                name: {{ .Values.puppetdb.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/opt/puppetlabs/server/data/puppetdb/scripts/crl_entrypoint.sh" ]
           securityContext:
@@ -295,11 +295,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.metrics.prometheus.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.metrics.prometheus.extraEnvSecret }}
+                name: {{ .Values.metrics.prometheus.extraEnvSecret }}
           {{- end }}
           ports:
             - name: metrics

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -76,11 +76,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.compilers.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+                name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c" ]
           args:
@@ -240,11 +240,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.compilers.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+                name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
           {{- end }}
           readinessProbe:
             httpGet:
@@ -333,11 +333,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.code.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.code.extraEnvSecret }}
+                name: {{ .Values.r10k.code.extraEnvSecret }}
           {{- end }}
           command:
             {{- range .Values.r10k.code.command }}
@@ -402,11 +402,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.hiera.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+                name: {{ .Values.r10k.hiera.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh" ]
           securityContext:
@@ -468,15 +468,15 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
           {{- end }}
           {{- if .Values.singleCA.crl.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.singleCA.crl.extraEnvSecret }}
+                name: {{ .Values.singleCA.crl.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ]
           securityContext:

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -73,6 +73,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.compilers.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+          {{- end }}
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /etc/puppetlabs/puppet/eyaml/keys;
@@ -228,6 +237,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.compilers.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /status/v1/simple
@@ -312,6 +330,15 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.code.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.code.extraEnvSecret }}
+          {{- end }}
           command:
             {{- range .Values.r10k.code.command }}
             - {{ . | quote }}
@@ -372,6 +399,15 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.hiera.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+          {{- end }}
           command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh" ]
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
@@ -428,6 +464,19 @@ spec:
           {{- range $key, $value := .Values.singleCA.crl.extraEnv }}
           - name: {{ $key }}
             value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.masters.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.singleCA.crl.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.singleCA.crl.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ]
           securityContext:

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -374,9 +374,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              {{- range .values.r10k.code.readinessProbe }}
-              - {{ . | quote }}
-              {{- end}}
+              {{- include "r10k.code.readinessProbe" .  | nindent 16 }}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 20

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -79,11 +79,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c" ]
           args:
@@ -255,11 +255,11 @@ spec:
           envFrom:
             {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
             {{- end }}
             {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
             {{- end }}
           readinessProbe:
             httpGet:
@@ -352,11 +352,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.code.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.code.extraEnvSecret }}
+                name: {{ .Values.r10k.code.extraEnvSecret }}
           {{- end }}
           command:
             {{- range .Values.r10k.code.command }}
@@ -427,11 +427,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.hiera.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+                name: {{ .Values.r10k.hiera.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh" ]
           securityContext:
@@ -493,15 +493,15 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.masters.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+                name: {{ .Values.puppetserver.masters.extraEnvSecret }}
           {{- end }}
           {{- if .Values.singleCA.crl.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.singleCA.crl.extraEnvSecret }}
+                name: {{ .Values.singleCA.crl.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ]
           securityContext:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -76,6 +76,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.masters.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+          {{- end }}
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /etc/puppetlabs/puppet/eyaml/keys;
@@ -243,6 +252,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+            {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+            {{- end }}
+            {{- if .Values.puppetserver.masters.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /status/v1/simple
@@ -331,6 +349,15 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.code.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.code.extraEnvSecret }}
+          {{- end }}
           command:
             {{- range .Values.r10k.code.command }}
             - {{ . | quote }}
@@ -397,6 +424,15 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.hiera.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+          {{- end }}
           command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh" ]
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
@@ -453,6 +489,19 @@ spec:
           {{- range $key, $value := .Values.singleCA.crl.extraEnv }}
           - name: {{ $key }}
             value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.masters.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.masters.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.singleCA.crl.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.singleCA.crl.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ]
           securityContext:

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -69,6 +69,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.compilers.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+          {{- end }}
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /etc/puppetlabs/puppet/eyaml/keys;
@@ -226,6 +235,15 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.compilers.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /status/v1/simple
@@ -282,6 +300,15 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.code.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.code.extraEnvSecret }}
+          {{- end }}
           command:
             {{- include "r10k.code.readinessProbe" . | nindent 16 }}
           args:
@@ -336,6 +363,15 @@ spec:
           {{- range $key, $value := .Values.r10k.hiera.extraEnv }}
           - name: {{ $key }}
             value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.r10k.hiera.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.r10k.hiera.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh" ]
           securityContext:
@@ -393,6 +429,19 @@ spec:
           {{- range $key, $value := .Values.puppetserver.compilers.extraEnv }}
           - name: {{ $key }}
             value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.singleCA.crl.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.singleCA.crl.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.puppetserver.compilers.extraEnvSecret }}
+            - secretRef:
+              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ] #
           securityContext:

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -248,7 +248,7 @@ spec:
             httpGet:
               path: /status/v1/simple
               port: {{ template "puppetserver.puppetserver-compilers.port" . }}
-              scheme: {{ .Values.puppetserver.compilers.readinessProbePeScheme }}
+              scheme: {{ .Values.puppetserver.compilers.readinessProbeScheme }}
             periodSeconds: {{ .Values.puppetserver.compilers.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.puppetserver.compilers.readinessProbeTimeout }}
             failureThreshold: {{ .Values.puppetserver.compilers.readinessProbeFailureThreshold }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -310,7 +310,9 @@ spec:
                 name: {{ .Values.r10k.code.extraEnvSecret }}
           {{- end }}
           command:
-            {{- include "r10k.code.readinessProbe" . | nindent 16 }}
+            {{- range .Values.r10k.code.command }}
+            - {{ . | quote }}
+            {{- end}}
           args:
             {{- range .Values.r10k.code.args }}
             - {{ . | quote }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -72,11 +72,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.compilers.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+                name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c" ]
           args:
@@ -238,11 +238,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.compilers.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+                name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
           {{- end }}
           readinessProbe:
             httpGet:
@@ -303,11 +303,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.code.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.code.extraEnvSecret }}
+                name: {{ .Values.r10k.code.extraEnvSecret }}
           {{- end }}
           command:
             {{- include "r10k.code.readinessProbe" . | nindent 16 }}
@@ -367,11 +367,11 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.r10k.hiera.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.r10k.hiera.extraEnvSecret }}
+                name: {{ .Values.r10k.hiera.extraEnvSecret }}
           {{- end }}
           command: [ "sh", "-c", "/etc/puppetlabs/puppet/r10k_hiera_entrypoint.sh" ]
           securityContext:
@@ -433,15 +433,15 @@ spec:
           envFrom:
           {{- if .Values.global.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.global.extraEnvSecret }}
+                name: {{ .Values.global.extraEnvSecret }}
           {{- end }}
           {{- if .Values.singleCA.crl.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.singleCA.crl.extraEnvSecret }}
+                name: {{ .Values.singleCA.crl.extraEnvSecret }}
           {{- end }}
           {{- if .Values.puppetserver.compilers.extraEnvSecret }}
             - secretRef:
-              name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
+                name: {{ .Values.puppetserver.compilers.extraEnvSecret }}
           {{- end }}
           command: ["sh", "-c", "/etc/puppetlabs/puppet/ssl/crl_entrypoint.sh" ] #
           securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,8 @@ global:
     runAsUser: 999  # "puppet" UID
     runAsGroup: 999 # "puppet" GID
 
+  extraEnv: {}
+  extraEnvSecret: ""
   extraLabels: {}
 
 
@@ -215,6 +217,8 @@ puppetserver:
     ## Additional Masters' container environment variables
     ##
     extraEnv: {}
+    ## Additional Masters' container environment variables from a pre-existing K8s secret
+    extraEnvSecret: ""
 
     ## Additional Masters' container labels
     ##
@@ -399,6 +403,8 @@ puppetserver:
     ## Additional Compilers' container environment variables
     ##
     extraEnv: {}
+    ## Additional Compilers' container environment variables from a pre-existing K8s secret
+    extraEnvSecret: ""
 
     ## Additional Compilers' container labels
     ##
@@ -624,6 +630,8 @@ r10k:
     #   - --color
     ## Additional r10k code container environment variables
     extraEnv: {}
+     ## Additional r10k code container environment variables from a pre-existing K8s secret
+    extraEnvSecret: ""
     extraSettings: {}
     extraRepos: {}
     defaultRepoExtraConf: {}
@@ -673,6 +681,8 @@ r10k:
     #   - --color
     ## Additional puppetserver hiera container environment variables
     extraEnv: {}
+    ## Additional puppetserver hiera container environment variables from a pre-existing K8s secret
+    extraEnvSecret: ""
     extraSettings: {}
     extraRepos: {}
     defaultRepoExtraConf: {}
@@ -752,6 +762,8 @@ puppetdb:
   extraInitContainers: []
   ## Additional puppetdb container environment variables
   extraEnv: {}
+  ## Additional puppetdb container environment variables from a pre-existing K8s secret
+  extraEnvSecret: ""
 
   ## Additional puppetdb container labels
   ##
@@ -874,6 +886,8 @@ puppetboard:
   #  ENABLE_QUERY: True
   #  INVENTORY_FACTS: Hostname,fqdn,IP Address,ipaddress
   #  GRAPH_FACTS: architecture,puppetversion,osfamily
+  ## Additional puppetboard container environment variables from a pre-existing K8s secret
+  extraEnvSecret: ""
   securityContext:
     runAsNonRoot: true
     allowPrivilegeEscalation: false
@@ -1030,8 +1044,10 @@ singleCA:
       failedJobsHistoryLimit: 2
       successfulJobsHistoryLimit: 1
 
-
+    ## Additional r10k container environment variables
     extraEnv: {}
+    ## Additional r10k container environment variables from a pre-existing K8s secret
+    extraEnvSecret: ""
     resources: {}
     #  requests:
     #    memory: 128Mi
@@ -1076,6 +1092,8 @@ metrics:
       # PUPPETDB_UNREPORTED_NODE: 2h
       # REPORT_METRICS_CATEGORIES: 'resources,time,changes,events'
       # PUPPETDB_SSL_SKIP_VERIFY: "True"
+    ## Additional PuppetDB exporter container environment variables from a pre-existing K8s secret
+    extraEnvSecret: ""
     ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
     metricRelabelings: []
     ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config

--- a/values.yaml
+++ b/values.yaml
@@ -767,7 +767,8 @@ puppetdb:
   ## Extra initContainers to inject into the PuppetDB pod
   extraInitContainers: []
   ## Additional puppetdb container environment variables
-  extraEnv: {}
+  extraEnv:
+    PUPPETDB_JAVA_ARGS: "-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xloggc:/opt/puppetlabs/server/data/puppetdb/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048"
   ## Additional puppetdb container environment variables from a pre-existing K8s secret
   extraEnvSecret: ""
 

--- a/values.yaml
+++ b/values.yaml
@@ -768,7 +768,7 @@ puppetdb:
   extraInitContainers: []
   ## Additional puppetdb container environment variables
   extraEnv:
-    PUPPETDB_JAVA_ARGS: "-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xloggc:/opt/puppetlabs/server/data/puppetdb/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048"
+    PUPPETDB_JAVA_ARGS: "-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc:/opt/puppetlabs/server/data/puppetdb/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048"
   ## Additional puppetdb container environment variables from a pre-existing K8s secret
   extraEnvSecret: ""
 


### PR DESCRIPTION
# Feature
Fixes #193 

Tested by deploying our usual setup from this branch - helm reports no changes to any resources. `envFrom` is not populated:
```
 ~  k get pod puppetserver-puppetserver-master-7458c5f9f7-qcms6 -oyaml | grep envFrom -A2
```

Redeployed after adding the following to Helm values:
```
puppetserver:
  masters:
    extraEnvSecret: puppetserver-env
```

Which resulted in the following changes:
```
 ~  k get pod puppetserver-puppetserver-master-85946b589c-rrsnl -oyaml | grep envFrom -A2
    envFrom:
    - secretRef:
        name: puppetserver-env
--
    envFrom:
    - secretRef:
        name: puppetserver-env
```

By executing `k exec -ti puppetserver-puppetserver-master-85946b589c-rrsnl /usr/bin/env` I am able to see all of the environment variables populated from secret `puppetserver-env` key/value pairs.

## Usage example

One of the possible uses is to create custom entrypoints with secret values. For example, some internal Puppet function might need a file with credentials:
```
puppetserver:
  customentrypoints:
    enabled: true
    configmaps:
      01_some_dependencies.sh: |-
        #!/bin/bash
        echo "{\"client_id\":\"${JWT_CLIENT}\",\"client_secret\":\"${JWT_SECRET}\"}" > /etc/jwt_credentials.json
```

I'm sure there's many other use cases for this.

# Bugfixes
- There is no readinessProbePeScheme, probably leftover when copy+pasting. Fixing to readinessProbeScheme.
- Fix PuppetDB [defaulting](https://github.com/voxpupuli/container-puppetdb/blob/main/puppetdb/Dockerfile#L33) to deprecated `-Xloggc` flag and using a non existent path for GC logs.
- Broken r10k-code command for statefulset compilers breaks chart when using them
- Standardize r10k-code readiness probe usage as it is different across deployment methods