### PR TITLE
Restic: Fix breaking typo, add ability for custom CA certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
-## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-17)
+## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)
+- Fix: Typo in the restic backup template preventing chart from being deployed
+
+## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-20)
 - Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
 
 ## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 NOTE: The change log until version `v0.2.4` is auto-generated.
 ## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)
 - Fix: Typo in the restic backup template preventing chart from being deployed
+- Feat: Add ability to mount custom ca-certificates.crt from configMap for Restic
 
 ## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-20)
 - Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 8.1.4
+version: 8.1.5
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.masters.backup.image` | puppetserver restic backup CronJob image | `restic/restic`|
 | `puppetserver.masters.backup.tag` | puppetserver restic backup CronJob image tag | `0.13.1`|
 | `puppetserver.masters.backup.pullPolicy` | puppetserver restic backup CronJob image pullPolicy | `IfNotPresent`|
+| `puppetserver.masters.backup.caConfigMap` | puppetserver restic backup CronJob configmap for custom ca-certificates.crt | ``|
 | `puppetserver.masters.backup.restic.keep_last` | puppetserver restic backup CronJob keep last n days | `90`|
 | `puppetserver.masters.backup.restic.repository` | puppetserver restic backup CronJob s3 compatible repository | ``|
 | `puppetserver.masters.backup.restic.access_key_id` | puppetserver restic backup CronJob s3 access_key_id | ``|

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
           volumes:
           - name: puppet-ca-storage
             persistentVolumeClaim:
-              claimName: {{ template "puppetserver.persitence.ca.claimName" . }}
+              claimName: {{ template "puppetserver.persistence.ca.claimName" . }}
           - name: puppet-puppet-storage
             persistentVolumeClaim:
               claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -69,6 +69,11 @@ spec:
               mountPath: /backup/etc/puppetlabs/puppetserver/ca/
             - name: puppet-puppet-storage
               mountPath: /backup/etc/puppetlabs/puppet/
+            {{- if .Values.puppetserver.masters.backup.caConfigMap }}
+            - name: restic-ca-certificates
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: ca-certificates.crt
+            {{- end }}
           volumes:
           - name: puppet-ca-storage
             persistentVolumeClaim:
@@ -76,4 +81,10 @@ spec:
           - name: puppet-puppet-storage
             persistentVolumeClaim:
               claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
+          {{- if .Values.puppetserver.masters.backup.caConfigMap }}
+          - name: restic-ca-certificates
+            configMap:
+              name: {{ .Values.puppetserver.masters.backup.caConfigMap }}
+              defaultMode: 0777
+          {{- end }}
 {{- end }}

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -475,7 +475,7 @@ spec:
             claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
         - name: puppet-serverdata-storage
           persistentVolumeClaim:
-            claimName: {{ template "puppetserver.persitence.data.claimName" . }}
+            claimName: {{ template "puppetserver.persistence.data.claimName" . }}
         {{- if .Values.singleCA.enabled }}
         - name: crl-volume
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -343,6 +343,12 @@ puppetserver:
       tag: 0.13.1
       pullPolicy: IfNotPresent
 
+      ## Replace ca-certificates.crt with your own CA bundle if needed
+      ##
+      caConfigMap: ""
+
+      ## Restric configuration
+      ##
       restic:
         keep_last: 90 # days
         repository: "" # "s3:https://s3.minio.xx/backups/"


### PR DESCRIPTION
## Bugfix
Due to a typo in the volumes within the restic backup template, enabling said backups will break the chart rendering it undeployable:

```
Error: UPGRADE FAILED: template: umbrella-chart/charts/puppetserver/templates/puppetserver-ca-backup-cronjob.yaml:75:37: executing "umbrella-chart/charts/puppetserver/templates/puppetserver-ca-backup-cronjob.yaml" at <{{template "puppetserver.persitence.ca.claimName" .}}>: template "puppetserver.persitence.ca.claimName" not defined
```

Fixing the typo.

## Feature
Add ability to mount a pre-existing configMap that contains `ca-certificates.crt` which will replace the existing file in the Restic container. This is needed for implementations that are under a self-signed certificate, e.g. an on premise S3 cluster based on Ceph or a S3 based on minio with custom certs.

Tested with an on-prem S3 implementation - errors out due to self-signed certs by default, works as expected when passing a custom CA via `caConfigMap`.