### PR TITLE
Use a custom CA file for r10k control repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v9.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.0) (2024-03-28)
+- Feat: Use custom CA file for r10k HTTPS code repository
+
 ## [v9.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.2.1) (2024-03-27)
 - Fix: Add 'netrc' credentials documentation for r10k and hiera repos
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.2.1
+version: 9.3.0
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.code.viaSsh.credentials.existingSecret`| r10k control repo ssh secret that holds ssh key and known hosts files |``|
 | `r10k.code.viaHttps.credentials.netrc.value`| r10k control repo https .netrc file |``|
 | `r10k.code.viaHttps.credentials.existingSecret`| r10k control repo https secret that holds .netrc file contents in `netrc` key |``|
+| `r10k.code.viaHttps.customCa.cert.value`| r10k control repo https custom CA file in PEM format |``|
+| `r10k.code.viaHttps.customCa.existingSecret`| r10k control repo https secret that holds custom CA file in PEM format in `cert` key |``|
 | `r10k.hiera.resources` | r10k hiera data resource limits |``|
 | `r10k.hiera.cronJob.enabled` | enable or disable r10k hiera data cron job schedule policy | `true`|
 | `r10k.hiera.cronJob.schedule` | r10k hiera data cron job schedule policy | `*/2 * * * *`|

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,6 +40,14 @@ Create the args array for "r10k_code_cronjob.sh"
 {{- end -}}
 
 {{/*
+Create the base URL for custom CA repo configuration
+*/}}
+{{- define "r10k.code.viaHttps.customCa.repoUrl" -}}
+{{- $parsedRepo := urlParse .Values.puppetserver.puppeturl -}}
+{{- printf "%s://%s" $parsedRepo.scheme $parsedRepo.host }}
+{{- end -}}
+
+{{/*
 Create the args array for "r10k_hiera_cronjob.sh"
 */}}
 {{- define "r10k.hiera.args" -}}
@@ -575,6 +583,18 @@ Create the name for the r10k.code.viaHttps secret.
   {{- .Values.r10k.code.viaHttps.credentials.existingSecret -}}
 {{- else -}}
   {{ template "puppetserver.fullname" . }}-r10k-code-creds
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the r10k.code.viaHttps.customCa secret.
+ Defaults to "r10k.code.viaHttps.secret"
+*/}}
+{{- define "r10k.code.viaHttps.customCa.secret" -}}
+{{- if .Values.r10k.code.viaHttps.customCa.existingSecret -}}
+  {{- .Values.r10k.code.viaHttps.customCa.existingSecret -}}
+{{- else -}}
+  {{ template "r10k.code.viaHttps.secret" . }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -81,6 +81,13 @@ spec:
             subPath: .netrc
           {{- end }}
           {{- end }}
+          {{- with .Values.r10k.code.viaHttps.customCa }}
+          {{- if or .existingSecret .cert.value }}
+          - name: r10k-code-cert
+            mountPath: /home/puppet/code-certs/ca.pem
+            subPath: ca.pem
+          {{- end }}
+          {{- end }}
           - name: puppet-code-storage
             mountPath: /etc/puppetlabs/code/
           - name: r10k-code-volume
@@ -198,6 +205,15 @@ spec:
                 path: id_rsa
               - key: known_hosts
                 path: known_hosts
+        {{- end }}
+        {{- if or .Values.r10k.code.viaHttps.customCa.existingSecret .Values.r10k.code.viaHttps.customCa.cert.value }}
+        - name: r10k-code-cert
+          secret:
+            secretName: {{ template "r10k.code.viaHttps.customCa.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: cert
+                path: ca.pem
         {{- end }}
         {{- if or .Values.r10k.code.viaHttps.credentials.existingSecret .Values.r10k.code.viaHttps.credentials.netrc.value }}
         - name: r10k-code-netrc

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -369,6 +369,13 @@ spec:
             subPath: .netrc
           {{- end }}
           {{- end }}
+          {{- with .Values.r10k.code.viaHttps.customCa }}
+          {{- if or .existingSecret .cert.value }}
+          - name: r10k-code-cert
+            mountPath: /home/puppet/code-certs/ca.pem
+            subPath: ca.pem
+          {{- end }}
+          {{- end }}
           - name: puppet-code-storage
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-storage
@@ -613,6 +620,15 @@ spec:
             items:
               - key: netrc
                 path: .netrc
+        {{- end }}
+        {{- if or .Values.r10k.code.viaHttps.customCa.existingSecret .Values.r10k.code.viaHttps.customCa.cert.value }}
+        - name: r10k-code-cert
+          secret:
+            secretName: {{ template "r10k.code.viaHttps.customCa.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: cert
+                path: ca.pem
         {{- end }}
         - name: r10k-code-volume
           configMap:

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -392,6 +392,13 @@ spec:
             subPath: .netrc
           {{- end }}
           {{- end }}
+          {{- with .Values.r10k.code.viaHttps.customCa }}
+          {{- if or .existingSecret .cert.value }}
+          - name: r10k-code-cert
+            mountPath: /home/puppet/code-certs/ca.pem
+            subPath: ca.pem
+          {{- end }}
+          {{- end }}
           - name: puppet-code-storage
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-storage
@@ -679,6 +686,15 @@ spec:
             items:
               - key: netrc
                 path: .netrc
+        {{- end }}
+        {{- if or .Values.r10k.code.viaHttps.customCa.existingSecret .Values.r10k.code.viaHttps.customCa.cert.value }}
+        - name: r10k-code-cert
+          secret:
+            secretName: {{ template "r10k.code.viaHttps.customCa.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: cert
+                path: ca.pem
         {{- end }}
         {{- if .Values.puppetserver.puppeturl }}
         - name: r10k-code-volume

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -339,6 +339,13 @@ spec:
             subPath: .netrc
           {{- end }}
           {{- end }}
+          {{- with .Values.r10k.code.viaHttps.customCa }}
+          {{- if or .existingSecret .cert.value }}
+          - name: r10k-code-cert
+            mountPath: /home/puppet/code-certs/ca.pem
+            subPath: ca.pem
+          {{- end }}
+          {{- end }}
           - name: puppet-code-volume
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-volume
@@ -594,6 +601,15 @@ spec:
             items:
               - key: netrc
                 path: .netrc
+        {{- end }}
+        {{- if or .Values.r10k.code.viaHttps.customCa.existingSecret .Values.r10k.code.viaHttps.customCa.cert.value }}
+        - name: r10k-code-cert
+          secret:
+            secretName: {{ template "r10k.code.viaHttps.customCa.secret" . }}
+            defaultMode: 288 # = mode 0440
+            items:
+              - key: cert
+                path: ca.pem
         {{- end }}
         {{- if .Values.puppetserver.puppeturl }}
         - name: r10k-code-volume

--- a/templates/r10k-code-secret.yaml
+++ b/templates/r10k-code-secret.yaml
@@ -19,5 +19,10 @@ data:
   netrc: {{ .netrc.value | b64enc | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.r10k.code.viaHttps.customCa }}
+  {{- if .cert.value }}
+  cert: {{ .cert.value | b64enc | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -51,6 +51,9 @@ data:
     tail -Fq ~/.r10k_code_cronjob.out &
     {{- end }}
     touch {{ .Values.r10k.code.cronJob.successFile }} > /dev/null 2>&1
+    {{- if .Values.r10k.code.viaHttps.customCa }}
+    git config --global http."{{ template "r10k.code.viaHttps.customCa.repoUrl" .}}".sslCAInfo ~/code-certs/ca.pem
+    {{- end }}
     {{- if .Values.r10k.code.cronJob.enabled }}
     exec supercronic ~/.r10k_code_crontab
     {{- else}}

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.2.1
+            helm.sh/chart: puppetserver-9.3.0
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.2.1
+            helm.sh/chart: puppetserver-9.3.0
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.2.1
+        helm.sh/chart: puppetserver-9.3.0
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/values.yaml
+++ b/values.yaml
@@ -672,6 +672,12 @@ r10k:
         ## from a pre-existing K8s secret
         ## NOTE: Using this secret supercedes all other credentials settings.
         existingSecret: ""
+      customCa:
+        cert:
+          ## A multi-line string
+          value: # |
+            # PEM-encoded custom CA certificates
+        existingSecret: ""
     viaSsh:
       credentials:
         ssh:

--- a/values.yaml
+++ b/values.yaml
@@ -675,7 +675,7 @@ r10k:
       customCa:
         cert:
           ## A multi-line string
-          value: # |
+          value:  # |
             # PEM-encoded custom CA certificates
         existingSecret: ""
     viaSsh:


### PR DESCRIPTION
In my use case the control repo is in a private repository which is cloned via HTTPS. The Gitlab instance where the repo lives is behind a reverse proxy which serves the repositories, and that reverser proxy has a certificate issued by an internal CA. 

In order for r10k to retrieve the repository, I have had to configure the `netrc` file, which was already present in the chart but not documented (#211), and find a way for r10k to handle the custom CA of my Gitlab instance.

This PR adds two new configuration settings:

* `r10k.code.viaHttps.customCa.cert.value`: A multiline file where the custom CA certificate chain can be stored in PEM format. This certificate is stored inside the `r10k-code-secret` within the `cert` key.
* `r10k.code.viaHttps.customCa.existingSecret`: A secret reference which must store the certificate chain in PEM format inside the `cert` key

The certificate is mounted as `~/code-certs/ca.pem` file in the container where r10k is running and then this command is launched in the entry point of the container:

```
git config --global http."{{ template "r10k.code.viaHttps.customCa.repoUrl" .}}".sslCAInfo ~/code-certs/ca.pem
```

The template `r10k.code.viaHttps.customCa.repoUrl` extracts the base URL from the `puppetserver.puppeturl`, so git can check if the TLS certificate from the HTTPS repository matches the custom CA.

I have bumped the version and changelog of the chart, but it you need more changes or me to modify anything, please contact me.
