### PR TITLE
Fix permission issue and template issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v9.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.1) (2024-04-08)
+- Fix: Fixes bug in puppet-preinstall template when puppetserver.preGeneratedCertsJob is enabled. 
 
 ## [v9.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.1) (2024-04-03)
 - Fix: Fixes bug when viaHttps.customCa is not provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
-## [v9.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.1) (2024-04-08)
+## [v9.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.2) (2024-04-08)
 - Fix: Fixes bug in puppet-preinstall template when puppetserver.preGeneratedCertsJob is enabled. 
 
 ## [v9.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.1) (2024-04-03)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.3.1
+version: 9.3.2
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -407,4 +407,3 @@ spec:
           emptyDir: {}
         {{- end }}
 {{- end }}
-

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -167,9 +167,11 @@ spec:
               mountPath: /crl
             {{- end }}
             {{- end }}
+          {{- if .Values.global.runAsNonRoot }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
             runAsGroup: {{ .Values.global.securityContext.runAsGroup }}
+          {{- end }}
         {{- if .Values.puppetdb.enabled }}
         - name: copy-ro-puppetdb-certs
           image: "{{.Values.puppetdb.image}}:{{.Values.puppetdb.tag}}"
@@ -223,9 +225,11 @@ spec:
               mountPath: /crl
             {{- end }}
             {{- end }}
+          {{- if .Values.global.runAsNonRoot }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
             runAsGroup: {{ .Values.global.securityContext.runAsGroup }}
+          {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.global.runAsNonRoot }}
@@ -373,7 +377,7 @@ spec:
         - name: puppetserver-certs
         {{- if not .Values.singleCA.enabled }}
           configMap:
-            name: "{{ template "puppetserver.fullname" . }}-puppetserver-preinstall"
+            name: "{{ template "puppetserver.fullname" . }}-preinstall"
         {{- else }}
           secret:
             secretName: {{ .Values.singleCA.certificates.existingSecret.puppetserver }}
@@ -403,3 +407,4 @@ spec:
           emptyDir: {}
         {{- end }}
 {{- end }}
+

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.3.1
+            helm.sh/chart: puppetserver-9.3.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.3.1
+            helm.sh/chart: puppetserver-9.3.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.1
+        helm.sh/chart: puppetserver-9.3.2
       name: puppetserver-puppet-claim
     spec:
       accessModes:


### PR DESCRIPTION
First two changes will fix the puppetdb-preinit container from failing with a `mkdir: cannot create directory ‘/opt/puppetlabs/server/data/puppetdb/certs’: Permission denied` when `puppetmasters.preGeneratedCertsJob.enabled` is set to true. 
 as it tries to run as non-root by default even if it's disabled.
Second change fixes a broken reference to the puppetmaster-preinstall configmap which prevents the server from starting up correctly when `puppetmasters.preGeneratedCertsJob.enabled` is set to true.