### PR TITLE
Fix: Update cURL container to address CVE-2023-38545 & CVE-2023-38546

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+
+## [v9.3.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.2) (2024-04-10)
+- Fix: Update cURL container to address CVE-2023-38545 & CVE-2023-38546
+
 ## [v9.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.2) (2024-04-08)
 - Fix: Fixes bug in puppet-preinstall template when puppetserver.preGeneratedCertsJob is enabled. 
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.3.2
+version: 9.3.3
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.3.2
+            helm.sh/chart: puppetserver-9.3.3
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.3.2
+            helm.sh/chart: puppetserver-9.3.3
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.2
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-statefulset.compilers_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-statefulset.compilers_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-8.3.0
+        helm.sh/chart: puppetserver-9.3.3
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-8.3.0
+            helm.sh/chart: puppetserver-9.3.3
         spec:
           containers:
             - env:

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,7 @@ global:
 
   curl:
     image: curlimages/curl
-    tag: 7.87.0
+    tag: 8.7.1
     imagePullPolicy: IfNotPresent
 
   r10k:


### PR DESCRIPTION
This PR updates the version of curl to the latest stable release, and thereby addresses CVE-2023-38545 & CVE-2023-38546. This is a safe change given the usage of curl within the chart, and will mitigate any potential container vulnerability scanner findings by deploying this chart in enterprise environments.