### PR TITLE
Fix: Bump bitnami/jmx-exporter to latest stable for container patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v9.3.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.2) (2024-04-10)
+## [v9.3.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.4) (2024-04-11)
+- Fix: Bump bitnami/jmx-exporter to latest stable for container patches
+
+## [v9.3.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.3) (2024-04-10)
 - Fix: Update cURL container to address CVE-2023-38545 & CVE-2023-38546
 
 ## [v9.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.2) (2024-04-08)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.3.3
+version: 9.3.4
 appVersion: 7.13.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.3.3
+            helm.sh/chart: puppetserver-9.3.4
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.13.0
-            helm.sh/chart: puppetserver-9.3.3
+            helm.sh/chart: puppetserver-9.3.4
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.13.0
-        helm.sh/chart: puppetserver-9.3.3
+        helm.sh/chart: puppetserver-9.3.4
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,7 @@ global:
 
   jmxexporter:
     image: bitnami/jmx-exporter
-    tag: 0.20.0-debian-11-r1
+    tag: 0.20.0-debian-12-r13
     imagePullPolicy: IfNotPresent
 
   ## Credentials for PuppetDB and PostgreSQL


### PR DESCRIPTION
This PR updates the bitnami/jmx-exporter container to the latest stable as published by Bitnami. This does not change the version of the jmx-exporter itself, but rather the underlying container os, which will include patches for bundled software (as part of upgrading from debian 11 to debian 12)