### PR TITLE
fixes #215 and allows customconfigs deployments in puppetdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 
 ## [v9.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.1) (2024-05-02)
 - Feat: allow option to import CA to only deal with CA and not puppetdb
+- Fix: #215 fixed ability to use customconfigs with PuppetDB
 
 ## [v9.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.0) (2024-04-19)
 - Fix: Update Vox Pupuli Containers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v9.4.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.2) (2024-05-03)
+- Fix: #215 fixed ability to use customconfigs with PuppetDB
+
 ## [v9.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.1) (2024-05-02)
 - Feat: allow option to import CA to only deal with CA and not puppetdb
-- Fix: #215 fixed ability to use customconfigs with PuppetDB
 
 ## [v9.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.0) (2024-04-19)
 - Fix: Update Vox Pupuli Containers

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.4.1
+version: 9.4.2
 appVersion: 7.17.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -352,11 +352,6 @@ spec:
           configMap:
             name: {{ include "puppetdb.fullname" . }}-custom-configs
         {{- end }}
-        {{- if .Values.puppetdb.customconfigs.enabled }}
-        - name: puppetdb-custom-configs
-          configMap:
-            name: puppetdb-custom-configs
-        {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 10 }}

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.1
+            helm.sh/chart: puppetserver-9.4.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.1
+            helm.sh/chart: puppetserver-9.4.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppet-claim
     spec:
       accessModes:


### PR DESCRIPTION
fixes #215 and allows customconfigs deployments in puppetdb by removing the duplicate volume mount block