### PR TITLE
Ability to disable persistence of `var-dir` and `confd` volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v9.4.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.2) (2024-05-03)
+- Feat: ability to disable persistence of `var-dir` and `confd` volumes
+
 ## [v9.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.1) (2024-05-02)
 - Feat: allow option to import CA to only deal with CA and not puppetdb
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.4.2
+version: 9.5.0
 appVersion: 7.17.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.4.1
+version: 9.4.2
 appVersion: 7.17.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.image` | puppetserver image | `voxpupuli/container-puppetserver`|
 | `puppetserver.tag` | puppetserver img tag | `7.13.0`|
 | `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
+| `puppetserver.persistence.data.enabled`| Persists /opt/puppetlabs/server/data/puppetserver/ in a PVC |`true`|
 | `puppetserver.persistence.data.existingClaim`| If non-empty, use a pre-defined PVC for puppet data |``|
 | `puppetserver.persistence.data.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
 | `puppetserver.persistence.data.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
@@ -227,6 +228,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.persistence.ca.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |
 | `puppetserver.persistence.ca.annotations`| If existingClaim is empty, the annotations of the PVC created by the chart | the value of `storage.annotations` |
 | `puppetserver.persistence.ca.size`| If existingClaim is empty, the size of the PVC created by the chart | the value of `storage.size` |
+| `puppetserver.persistence.confd.enabled`| Persists /etc/puppetlabs/puppetserver/conf.d/ in a PVC |`true`|
 | `puppetserver.persistence.confd.existingClaim`| If non-empty, use a pre-defined PVC for the puppet conf.d directory |``|
 | `puppetserver.persistence.confd.accessModes`| If existingClaim is empty, the accessModes of the PVC created by the chart | the value of `storage.accessModes` |
 | `puppetserver.persistence.confd.storageClass`| If existingClaim is empty, the storageClass of the PVC created by the chart | the value of `storage.accessModes` |

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -93,8 +93,10 @@ spec:
               subPath: private_key.pkcs7.pem
             {{- end }}
             {{- end }}
+            {{- if eq .Values.puppetserver.persistence.data.enabled true }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- end}}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
@@ -285,8 +287,10 @@ spec:
               mountPath: /etc/puppetlabs/code/
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
+            {{- if eq .Values.puppetserver.persistence.data.enabled true }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- end }}
             - name: puppet-ca-storage
               mountPath: /etc/puppetlabs/puppetserver/ca/
             {{- range $key, $value := .Values.puppetserver.customconfigs.configmaps }}
@@ -341,9 +345,11 @@ spec:
         - name: puppet-ca-storage
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.ca.claimName" . }}
+        {{- if eq .Values.puppetserver.persistence.data.enabled true }}
         - name: puppet-serverdata-storage
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.data.claimName" . }}
+        {{- end }}
         - name: puppet-docker-entrypoint-config
           configMap:
             name: {{ template "puppetserver.fullname" . }}-docker-entrypoint-config

--- a/templates/puppetserver-confd-pvc.yaml
+++ b/templates/puppetserver-confd-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.puppetserver.persistence.confd.existingClaim) (not .Values.global.runAsNonRoot) }}
+{{- if and (not .Values.puppetserver.persistence.confd.existingClaim) (not .Values.global.runAsNonRoot) (eq .Values.puppetserver.persistence.confd.enabled true)}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/puppetserver-data-pvc.yaml
+++ b/templates/puppetserver-data-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.puppetserver.persistence.data.existingClaim }}
+{{- if and (not .Values.puppetserver.persistence.data.existingClaim) (eq .Values.puppetserver.persistence.data.enabled true) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -194,8 +194,10 @@ spec:
               mountPath: /tmp/puppet/configmap/eyaml/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
             {{- end }}
+            {{- if eq .Values.puppetserver.persistence.data.enabled true }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- end }}
       {{- end }}
       containers:
         - name: {{ template "puppetserver.fullname" . }}
@@ -277,8 +279,10 @@ spec:
               mountPath: /etc/puppetlabs/code/
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
+            {{- if eq .Values.puppetserver.persistence.data.enabled true }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- end }}
             {{- range $key, $value := .Values.puppetserver.customconfigs.configmaps }}
             - name: puppetserver-custom-configs
               mountPath: /etc/puppetlabs/puppetserver/conf.d/{{ $key }}
@@ -293,8 +297,10 @@ spec:
             - name: puppet-puppetserver
               mountPath: /etc/puppetlabs/puppetserver/
             {{- else }}
+            {{- if eq .Values.puppetserver.persistence.confd.enabled true }}
             - name: puppet-confd
               mountPath: /etc/puppetlabs/puppetserver/conf.d/
+            {{- end }}
             {{- end }}
             {{- if .Values.hiera.config }}
             - name: hiera-volume
@@ -572,9 +578,11 @@ spec:
         - name: puppet-puppet-storage
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.puppet.claimName" . }}
+        {{- if eq .Values.puppetserver.persistence.data.enabled true }}
         - name: puppet-serverdata-storage
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.data.claimName" . }}
+        {{- end }}
         {{- if .Values.singleCA.enabled }}
         - name: crl-volume
           configMap:
@@ -686,9 +694,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.server.claimName" . }}
         {{- else }}
+        {{- if eq .Values.puppetserver.persistence.confd.enabled true }}
         - name: puppet-confd
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.confd.claimName" . }}
+        {{- end }}
         {{- end }}
         {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
         - name: {{ $extraSecret.name }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -141,7 +141,9 @@ spec:
               mkdir -p /opt/puppetlabs/server/data/puppetserver/dropsonde/bin/;
               touch /opt/puppetlabs/server/data/puppetserver/dropsonde/bin/dropsonde;
               chown puppet:puppet -R /opt/puppetlabs/server/data/puppetserver/;
+              {{- if eq .Values.puppetserver.persistence.confd.enabled true }}
               cp -rp /etc/puppetlabs/puppetserver/conf.d/* /conf.d/;
+              {{- end}}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
@@ -162,8 +164,10 @@ spec:
                 - AUDIT_WRITE
                 - FOWNER
           volumeMounts:
+            {{- if eq .Values.puppetserver.persistence.confd.enabled true }}
             - name: puppet-confd
               mountPath: /conf.d/
+            {{- end}}
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
             {{- if and .Values.puppetserver.puppeturl (not .Values.puppetserver.compilers.enabled) }}
@@ -217,8 +221,10 @@ spec:
             - name: manifests-volume
               mountPath: /tmp/puppet/configmap/site.pp
               subPath: site.pp
+            {{- if eq .Values.puppetserver.persistence.data.enabled true }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- end }}
       {{- end }}
       containers:
         - name: {{ template "puppetserver.fullname" . }}
@@ -294,8 +300,10 @@ spec:
           volumeMounts:
             - name: puppet-puppet-storage
               mountPath: /etc/puppetlabs/puppet/
+            {{- if eq .Values.puppetserver.persistence.data.enabled true }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- end }}
             - name: puppet-ca-storage
               mountPath: /etc/puppetlabs/puppetserver/ca/
             {{- range $key, $value := .Values.puppetserver.customconfigs.configmaps }}
@@ -312,8 +320,10 @@ spec:
             - name: puppet-puppetserver
               mountPath: /etc/puppetlabs/puppetserver/
             {{- else }}
+            {{- if eq .Values.puppetserver.persistence.confd.enabled true }}
             - name: puppet-confd
               mountPath: /etc/puppetlabs/puppetserver/conf.d/
+            {{- end }}
             {{- end }}
             {{- if (not .Values.puppetserver.compilers.enabled) }}
             - name: puppet-code-storage
@@ -612,9 +622,11 @@ spec:
           configMap:
             name: {{ template "puppetserver.fullname" . }}-crl-config
         {{- end }}
+        {{- if eq .Values.puppetserver.persistence.data.enabled true }}
         - name: puppet-serverdata-storage
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.data.claimName" . }}
+        {{- end }}
         {{- if .Values.puppetserver.masters.multiMasters.enabled }}
         - name: init-masters-volume
           configMap:
@@ -729,9 +741,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.server.claimName" . }}
         {{- else }}
+        {{- if eq .Values.puppetserver.persistence.confd.enabled true }}
         - name: puppet-confd
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.confd.claimName" . }}
+        {{- end }}
         {{- end }}
         {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
         - name: {{ $extraSecret.name }}

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.1
+            helm.sh/chart: puppetserver-9.4.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.2
+            helm.sh/chart: puppetserver-9.5.0
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.2
+            helm.sh/chart: puppetserver-9.5.0
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.1
+            helm.sh/chart: puppetserver-9.4.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.5.0
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.1
+        helm.sh/chart: puppetserver-9.4.2
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/values.yaml
+++ b/values.yaml
@@ -107,6 +107,9 @@ puppetserver:
       size: ""
 
     data:
+      ## The data of this volume is overwritten on each start, so persistence can be disabled marking
+      ## this variable to false
+      enabled: true
       ## If an existing Persistent Volume Claim needs to be used, specify the name here.
       ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
       existingClaim: ''
@@ -126,6 +129,9 @@ puppetserver:
       size: ""
 
     confd:
+      ## The data of this volume is overwritten on each start, so persistence can be disabled marking
+      ## this variable to false
+      enabled: true
       ## If an existing Persistent Volume Claim needs to be used, specify the name here.
       ## If not specified the PVC is created by this chart using the informations below or the `storage` values.
       existingClaim: ''


### PR DESCRIPTION
Solves #220 

Adds these two parameters to the chart:

`.Values.puppetserver.persistence.data.enabled`
`.Values.puppetserver.persistence.confd.enabled`

With the default value to true to keep the current chart behaviour, but if they are changed to false, they disable the use of persistent volumes for

`/opt/puppetlabs/server/data/puppetserver/`
`/etc/puppetlabs/puppetserver/conf.d/`

This simplifies the multi-master and multi-compilers architecture because less volumes have to be shared between pods.