### PR TITLE
fixes #228 better check for puppetcerts when running multimaster to prevent infinite hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v9.4.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.3) (2024-05-09)
+- Fix: #228 - fixed check for puppet certs in a multimaster setup
+
 ## [v9.4.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.2) (2024-05-03)
 - Fix: #215 fixed ability to use customconfigs with PuppetDB
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.4.2
+version: 9.4.3
 appVersion: 7.17.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/puppetserver-init-configmap.yaml
+++ b/templates/puppetserver-init-configmap.yaml
@@ -11,13 +11,12 @@ metadata:
 data:
   check_for_masters.sh: |
     #!/usr/bin/env bash
-    PUPPET_SSL_CERT_PEM=/etc/puppetlabs/puppet/ssl/certs/puppet.pem
     if [[ -d "$PUPPET_SSL_DIR" ]]; then
         ls -la /etc/puppetlabs/puppet/ssl/certs/
         echo "A Puppetserver master has already started running."
         echo "Waiting to finish the generation of the Puppet SSL certs..."
         sleep 5
-        while [[ ! -f "$PUPPET_SSL_CERT_PEM" ]];
+        while ! [[ -n "$(find /etc/puppetlabs/puppet/ssl/certs -name 'puppet*.pem' | head -1)" ]];
             do
               echo "Still waiting..."
               sleep 5

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.2
+            helm.sh/chart: puppetserver-9.4.3
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.4.2
+            helm.sh/chart: puppetserver-9.4.3
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.4.2
+        helm.sh/chart: puppetserver-9.4.3
       name: puppetserver-puppet-claim
     spec:
       accessModes:


### PR DESCRIPTION
fixes #228 

basically instead of looking for a static file puppet.pem we use find to search for a file that has puppet and ends .pem

this allows for the potential that Kubernetes clusters where certs might get generated with fully qualified paths

Find has to be used because you can't do wildcard file tests in bash so you have to use find in a subshell to search for the wildcard then return a count of files